### PR TITLE
check for cluster phase in our 'is cluster ok' check

### DIFF
--- a/pkg/api/cluster_client.go
+++ b/pkg/api/cluster_client.go
@@ -147,15 +147,6 @@ func (c ClusterClient) Delete(ctx context.Context, id string) error {
 	return err
 }
 
-func (c *ClusterClient) HasOkCondition(conditions []models.Condition) bool {
-	for _, cond := range conditions {
-		if *cond.Type_ == "biganimal.com/deployed" && *cond.ConditionStatus == "True" {
-			return true
-		}
-	}
-	return false
-}
-
 type ClusterResponse struct {
 	Data struct {
 		ClusterId string `json:"clusterId"`

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -361,8 +361,8 @@ func (c *ClusterResource) retryFunc(ctx context.Context, d *schema.ResourceData,
 			return resource.NonRetryableError(fmt.Errorf("Error describing instance: %s", err))
 		}
 
-		if !client.HasOkCondition(cluster.Conditions) {
-			return resource.RetryableError(errors.New("Instance not yet ready"))
+		if !cluster.IsHealthy() {
+			return resource.RetryableError(errors.New("Instance not yet health"))
 		}
 
 		if err := c.read(ctx, d, meta); err != nil {


### PR DESCRIPTION
fixes #20 

Moves the `IsOk()` check from the api client to the cluster model, and also includes a check for a 'healthy' phase

merge after #19 
