### PR TITLE
fix: send the cluster_architecture in on cluster updates

### DIFF
--- a/pkg/models/architecture.go
+++ b/pkg/models/architecture.go
@@ -1,7 +1,6 @@
 package models
 
 type Architecture struct {
-	ClusterArchitectureId   string `json:"clusterArchitectureId" mapstructure:"id"`
-	ClusterArchitectureName string `json:"clusterArchitectureName,omitempty" mapstructure:"name,omitempty"`
-	Nodes                   int    `json:"nodes" mapstructure:"nodes"`
+	ClusterArchitectureId string `json:"clusterArchitectureId" mapstructure:"id"`
+	Nodes                 int    `json:"nodes" mapstructure:"nodes"`
 }

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -89,7 +89,6 @@ func NewClusterForCreate(d *schema.ResourceData) (*Cluster, error) {
 
 func NewClusterForUpdate(d *schema.ResourceData) (*Cluster, error) {
 	c, err := NewCluster(d)
-	c.ClusterArchitecture = nil
 	c.ClusterId = nil
 	c.PgType = nil
 	c.PgVersion = nil


### PR DESCRIPTION
fixes https://github.com/EnterpriseDB/terraform-provider-biganimal/issues/18

This re-enables the cluster_architecture property and removes the 'name' field from the model to allow the validations to proceed

merge after https://github.com/EnterpriseDB/terraform-provider-biganimal/pull/15

This PR is actually a clone of https://github.com/EnterpriseDB/terraform-provider-biganimal/pull/19 . I opened a new one, because i mucked up the git history in that branch while trying to sign the commits :)