### PR TITLE
fix: add a check on the cluster phase to make sure changes have been properly manifest

### DIFF
--- a/pkg/api/cluster_client.go
+++ b/pkg/api/cluster_client.go
@@ -147,15 +147,6 @@ func (c ClusterClient) Delete(ctx context.Context, id string) error {
 	return err
 }
 
-func (c *ClusterClient) HasOkCondition(conditions []models.Condition) bool {
-	for _, cond := range conditions {
-		if *cond.Type_ == "biganimal.com/deployed" && *cond.ConditionStatus == "True" {
-			return true
-		}
-	}
-	return false
-}
-
 type ClusterResponse struct {
 	Data struct {
 		ClusterId string `json:"clusterId"`

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -5,6 +5,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const (
+	CONDITION_DEPLOYED = "biganimal.com/deployed"
+	PHASE_HEALTHY      = "Cluster in healthy state"
+)
+
 func NewCluster(d *schema.ResourceData) (*Cluster, error) {
 	allowedIpRanges, err := utils.StructFromProps[[]AllowedIpRange](d.Get("allowed_ip_ranges"))
 	if err != nil {
@@ -123,4 +128,18 @@ type Cluster struct {
 	Replicas                   *int              `json:"replicas,omitempty"`
 	ResizingPvc                []string          `json:"resizingPvc,omitempty"`
 	Storage                    *Storage          `json:"storage,omitempty"`
+}
+
+// IsHealthy checks to see if the cluster has the right condition 'biganimal.com/deployed'
+// as well as the correct 'healthy' phase.  '
+func (c Cluster) IsHealthy() bool {
+	if *c.Phase != PHASE_HEALTHY {
+		return false
+	}
+	for _, cond := range c.Conditions {
+		if *cond.Type_ == CONDITION_DEPLOYED && *cond.ConditionStatus == "True" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -361,7 +361,7 @@ func (c *ClusterResource) retryFunc(ctx context.Context, d *schema.ResourceData,
 			return resource.NonRetryableError(fmt.Errorf("Error describing instance: %s", err))
 		}
 
-		if !client.HasOkCondition(cluster.Conditions) {
+		if !cluster.IsHealthy() {
 			return resource.RetryableError(errors.New("Instance not yet ready"))
 		}
 


### PR DESCRIPTION
This is a rework of a previous PR, https://github.com/EnterpriseDB/terraform-provider-biganimal/pull/21 with changes addressed.  new PR, because rewriting the previous prs and commits to use a signed commit mucked up the history.

fixes https://github.com/EnterpriseDB/terraform-provider-biganimal/issues/20

Moves the IsOk() check from the api client to the cluster model, and also includes a check for a 'healthy' phase

merge after #33 