### PR TITLE
fix: use region_id instead of 'id' in the region model

### DIFF
--- a/examples/region_data/data.tf
+++ b/examples/region_data/data.tf
@@ -9,7 +9,8 @@ terraform {
 
 data "biganimal_region" "this" {
   cloud_provider = var.cloud_provider
-  region_id = "us-east-1"
+  region_id = var.region_id
+
 }
 
 output "regions" {

--- a/examples/region_data/variables.tf
+++ b/examples/region_data/variables.tf
@@ -7,3 +7,8 @@ variable "cloud_provider" {
     error_message = "Please select one of the supported regions: aws, azure."
   }
 }
+
+variable "region_id" {
+  type        = string
+  description = "region id"
+}

--- a/pkg/models/region.go
+++ b/pkg/models/region.go
@@ -1,7 +1,7 @@
 package models
 
 type Region struct {
-	Id        string `json:"regionId,omitempty" mapstructure:"id"`
+	Id        string `json:"regionId,omitempty" mapstructure:"region_id"`
 	Name      string `json:"regionName,omitempty" mapstructure:"name,omitempty"`
 	Status    string `json:"status,omitempty" mapstructure:"status,omitempty"`
 	Continent string `json:"continent,omitempty" mapstructure:"continent,omitempty"`


### PR DESCRIPTION
fixes #30 

the mapstructure struct tag of the region model was referencing `id`, while the terraform schema was referencing `region_id`.  this PR changes the mapstructure tag to `region_id`