### PR TITLE
ci: Spellcheck GH action

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,31 @@
+name: spellcheck-woke
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+
+  # Check code for non-inclusive language
+  woke:
+    name: Run woke
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+
+  # Enforce en-us spell check
+  spellcheck:
+    name: Run spellcheck
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Spellcheck
+        uses: rojopolis/spellcheck-github-actions@0.27.0

--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -1,0 +1,27 @@
+matrix:
+- name: markdown
+  sources:
+  - 'docs/**/*.md'
+  default_encoding: utf-8
+  aspell:
+    lang: en
+    d: en_US
+  dictionary:
+    wordlists:
+    - .wordlist-en-custom.txt
+  pipeline:
+    - pyspelling.filters.context:
+        context_visible_first: true
+        delimiters:
+          # Ignore multiline content between fences (fences can have 3 or more back ticks)
+          # ```
+          # content
+          # ```
+          - open: '(?s)^(?P<open> *`{3,})'
+            close: '^(?P=open)$'
+            # Ignore text between inline back ticks
+          - open: '(?P<open>`+)'
+            close: '(?P=open)'
+          - open: '(?P<open><!--)'
+            close: '(?P<close>-->)'
+    - pyspelling.filters.url:

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1,0 +1,13 @@
+BigAnimal
+CIDR
+GUC
+IOPS
+InstanceType
+Postgres
+biganimal
+config
+ip
+nestedatt
+nestedblock
+terraform
+uri


### PR DESCRIPTION
This PR adds two checkers:
- spellchecker
- checker for non-inclusive language. 

The `.wordlist-en-custom.txt` file is generated after the output of the spellchecker. 

Please review. 

Related to #42.  Please merge it after merging #49 