### PR TITLE
fix: change cloud_provider and region_id as the variables

### DIFF
--- a/examples/region_data/data.tf
+++ b/examples/region_data/data.tf
@@ -9,7 +9,7 @@ terraform {
 
 data "biganimal_region" "this" {
   cloud_provider = var.cloud_provider
-  region_id = var.region_id
+  region_id      = var.region_id
 }
 
 output "regions" {

--- a/examples/region_resource/resource.tf
+++ b/examples/region_resource/resource.tf
@@ -8,9 +8,8 @@ terraform {
 }
 
 resource "biganimal_region" "this" {
-  cloud_provider = "aws"
-  region_id      = "us-east-1"
-  status         = "ACTIVE"
+  cloud_provider = var.cloud_provider
+  region_id      = var.region_id
 }
 
 output "region_status" {

--- a/examples/region_resource/variables.tf
+++ b/examples/region_resource/variables.tf
@@ -3,3 +3,7 @@ variable "cloud_provider" {
   description = "The name of the cloud provider"
 }
 
+variable "region_id" {
+  type        = string
+  description = "region id"
+}


### PR DESCRIPTION
A small change to pass cloud_provider and region_id as the variables when creating region resource.