### PR TITLE
Fix: extend timeout for creating a cluster

### DIFF
--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -256,7 +256,7 @@ func (c *ClusterResource) Create(ctx context.Context, d *schema.ResourceData, me
 	// retry until we get success
 	err = resource.RetryContext(
 		ctx,
-		d.Timeout(schema.TimeoutUpdate)-time.Minute,
+		d.Timeout(schema.TimeoutCreate)-time.Minute,
 		c.retryFunc(ctx, d, meta, clusterId))
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Extending timeout for creating a cluster