### PR TITLE
fix: Set ba_bearer_token and ba_api_uri provider arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The binary can also be compiled by `go build`, which will output the binary into
 
 ## Using the provider
 
-Until the provider is accepted into the terraform registry, it's necesary to install the binary into your local terraform cache using `make`, and to configure terraform to look in the right location to find the binary.
+Until the provider is accepted into the terraform registry, it's necessary to install the binary into your local terraform cache using `make`, and to configure terraform to look in the right location to find the binary for the BigAnimal terraform provider.
 
 Terraform can be configured by adding the following to your ~/.terraformrc file.
 
@@ -46,6 +46,24 @@ provider_installation {
   # the dev_overrides block, and so no other providers will be available.
   direct {}
 }
+```
+
+Now, you can configure your BigAnimal provider. This can be done in 2 ways:
+
+### Providing BigAnimal configuration in a provider block
+```hcl
+provider "biganimal" {
+  ba_bearer_token = <redacted> // See Getting and API Token section for details
+  // ba_api_uri   = "https://portal.biganimal.com/api/v2" // Optional
+}
+```
+### Configuring Environment Variables
+
+You can set `BA_BEARER_TOKEN` and `BA_API_URI` env vars.
+
+```bash
+export BA_BEARER_TOKEN=<redacted>
+export BA_API_URI=https://portal.biganimal.com/api/v2
 ```
 
 ### Getting an API Token
@@ -67,21 +85,14 @@ Have you finished the login successfully? (y/N) y
 }
 ```
 
-Once the token has been retrieved, set it in your environment as follows
+Once the `access_token` has been retrieved, you can write it to the provider block as described above.
+Alternatively, you can set it in your environment as follows
 
 ```bash
 export BA_BEARER_TOKEN=<REDACTED>
 ```
 
 After compiling, configuring the `.terraformrc` and fetching a token, the examples in the `./examples` folder can be run.
-
-### Configuring environment variables
-
-In order to access the BigAnimal API, you must also configure the following environment variable:
-
-```bash
-export BA_API_URI=https://portal.biganimal.com/api/v2
-```
 
 ## Debugging the provider
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -14,17 +13,14 @@ type API struct {
 	httpClient *http.Client
 }
 
-func NewAPI() *API {
-	url := os.Getenv("BA_API_URI")
-	token := os.Getenv("BA_BEARER_TOKEN")
-
+func NewAPI(ba_bearer_token string, ba_api_uri string) *API {
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
 	api := &API{
-		url,
-		token,
+		ba_api_uri,
+		ba_bearer_token,
 		httpClient,
 	}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -36,11 +36,16 @@ func New(version string) func() *schema.Provider {
 	return func() *schema.Provider {
 		p := &schema.Provider{
 			Schema: map[string]*schema.Schema{
-				"ba_token": {
+				"ba_bearer_token": {
 					Type:        schema.TypeString,
 					Sensitive:   false,
 					Required:    true,
 					DefaultFunc: schema.EnvDefaultFunc("BA_BEARER_TOKEN", nil),
+				},
+				"ba_api_uri": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("BA_API_URI", "https://portal.biganimal.com/api/v2"),
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
@@ -60,13 +65,16 @@ func New(version string) func() *schema.Provider {
 }
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (any, diag.Diagnostics) {
+
 	return func(ctx context.Context, schema *schema.ResourceData) (any, diag.Diagnostics) {
+		ba_bearer_token := schema.Get("ba_bearer_token").(string)
+		ba_api_uri := schema.Get("ba_api_uri").(string)
 		// set our meta to be a new api.API
 		// this can be turned into concrete clients
 		// by
 		// api.BuildAPI(meta).ClusterClient()
 		// or
 		// api.BuildAPI(meta).RegionClient()
-		return api.NewAPI(), nil
+		return api.NewAPI(ba_bearer_token, ba_api_uri), nil
 	}
 }


### PR DESCRIPTION
With this PR, BigAnimal provider block can take arguments. Before, terraform provider wasn't configurable via provider block. 
```hcl
provider "biganimal" {
  ba_bearer_token = <redacted> // See Getting and API Token section for details
  // ba_api_uri   = "https://portal.biganimal.com/api/v2" // Optional
}
```
* The naming for the provider block arguments and the environment variables are now the same.(before it was `ba_token` for argument and `BA_BEARER_TOKEN` for the env var.  
* I tried to update the README.md, I'm open to suggestions.
* ba_api_uri argument is added as optional, with the default value `"https://portal.biganimal.com/api/v2"`. 
* I would update the examples to include a provider configuration in a separate PR. 

Please review. 
