### PR TITLE
Add EHA resource example and remove deprecated replicas

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -40,7 +40,6 @@ Sample cluster data source in the BigAnimal terraform provider .
 - `private_networking` (Boolean) Is private networking enabled
 - `read_only_connections` (Boolean) Is read only connections enabled
 - `region` (String) Region
-- `replicas` (Number) Replicas
 - `resizing_pvc` (List of String) Resizing PVC
 - `storage` (List of Object) Storage (see [below for nested schema](#nestedatt--storage))
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -25,7 +25,6 @@ Create a Postgres Cluster
 - `pg_type` (String) Postgres type
 - `pg_version` (String) Postgres Version
 - `region` (String) Region
-- `replicas` (Number) Replicas
 - `storage` (Block List, Min: 1) Storage (see [below for nested schema](#nestedblock--storage))
 
 ### Optional

--- a/examples/cluster_data/data.tf
+++ b/examples/cluster_data/data.tf
@@ -75,10 +75,6 @@ output "region" {
   value = data.biganimal_cluster.this.region
 }
 
-output "replicas" {
-  value = data.biganimal_cluster.this.replicas
-}
-
 output "resizing_pvc" {
   value = data.biganimal_cluster.this.resizing_pvc
 }

--- a/examples/cluster_resource/resource.tf
+++ b/examples/cluster_resource/resource.tf
@@ -60,7 +60,6 @@ resource "biganimal_cluster" "this_resource" {
   cloud_provider        = "azure"
   read_only_connections = false
   region                = "eastus2"
-  replicas              = 1
 }
 
 output "password" {

--- a/examples/eha_cluster_resource/resource.tf
+++ b/examples/eha_cluster_resource/resource.tf
@@ -59,7 +59,6 @@ resource "biganimal_cluster" "this_resource" {
   private_networking = false
   cloud_provider     = "aws"
   region             = "us-east-1"
-  replicas           = 1
 }
 
 output "password" {

--- a/examples/eha_cluster_resource/resource.tf
+++ b/examples/eha_cluster_resource/resource.tf
@@ -1,0 +1,72 @@
+terraform {
+  required_providers {
+    biganimal = {
+      source  = "biganimal"
+      version = "0.3.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.3.1"
+    }
+  }
+}
+
+resource "random_password" "password" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "biganimal_cluster" "this_resource" {
+  cluster_name = var.cluster_name
+
+  allowed_ip_ranges {
+    cidr_block  = "127.0.0.1/32"
+    description = "localhost"
+  }
+
+  allowed_ip_ranges {
+    cidr_block  = "192.168.0.1/32"
+    description = "description!"
+  }
+
+  backup_retention_period = "6d"
+  cluster_architecture {
+    id    = "eha"
+    nodes = 5
+  }
+
+  instance_type = "aws:c5.large"
+  password      = resource.random_password.password.result
+  pg_config {
+    name  = "application_name"
+    value = "created through terraform"
+  }
+
+  pg_config {
+    name  = "array_nulls"
+    value = "off"
+  }
+
+  storage {
+    volume_type       = "gp3"
+    volume_properties = "gp3"
+    size              = "4 Gi"
+  }
+
+  pg_type            = "epas"
+  pg_version         = "14"
+  private_networking = false
+  cloud_provider     = "aws"
+  region             = "us-east-1"
+  replicas           = 1
+}
+
+output "password" {
+  sensitive = true
+  value     = resource.biganimal_cluster.this_resource.password
+}
+
+output "connection_uri" {
+  value = resource.biganimal_cluster.this_resource.connection_uri
+}

--- a/examples/eha_cluster_resource/variables.tf
+++ b/examples/eha_cluster_resource/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster"
+}

--- a/examples/ha_cluster_resource/resource.tf
+++ b/examples/ha_cluster_resource/resource.tf
@@ -60,7 +60,6 @@ resource "biganimal_cluster" "this_resource" {
   cloud_provider        = "aws"
   read_only_connections = true
   region                = "us-east-1"
-  replicas              = 1
 }
 
 output "password" {

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -69,7 +69,6 @@ func NewCluster(d *schema.ResourceData) (*Cluster, error) {
 			Id: utils.GetString(d, "region"),
 		},
 		ReadOnlyConnections: utils.GetBoolP(d, "read_only_connections"),
-		Replicas:            utils.GetIntP(d, "replicas"),
 		Storage:             &storage,
 	}
 
@@ -126,7 +125,6 @@ type Cluster struct {
 	Provider                   *Provider         `json:"provider,omitempty"`
 	ReadOnlyConnections        *bool             `json:"readOnlyConnections,omitempty"`
 	Region                     *Region           `json:"region,omitempty"`
-	Replicas                   *int              `json:"replicas,omitempty"`
 	ResizingPvc                []string          `json:"resizingPvc,omitempty"`
 	Storage                    *Storage          `json:"storage,omitempty"`
 }

--- a/pkg/provider/data_source_cluster.go
+++ b/pkg/provider/data_source_cluster.go
@@ -170,11 +170,6 @@ func (c *ClusterData) Schema() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"replicas": {
-				Description: "Replicas",
-				Type:        schema.TypeInt,
-				Computed:    true,
-			},
 			"resizing_pvc": {
 				Description: "Resizing PVC",
 				Type:        schema.TypeList,
@@ -258,7 +253,6 @@ func (c *ClusterData) Read(ctx context.Context, d *schema.ResourceData, meta any
 	utils.SetOrPanic(d, "private_networking", cluster.PrivateNetworking)
 	utils.SetOrPanic(d, "cloud_provider", cluster.Provider)
 	utils.SetOrPanic(d, "region", cluster.Region)
-	utils.SetOrPanic(d, "replicas", cluster.Replicas)
 	utils.SetOrPanic(d, "storage", *cluster.Storage)
 	utils.SetOrPanic(d, "read_only_connections", cluster.ReadOnlyConnections)
 	utils.SetOrPanic(d, "resizing_pvc", cluster.ResizingPvc)

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -187,11 +187,6 @@ func (c *ClusterResource) Schema() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"replicas": {
-				Description: "Replicas",
-				Type:        schema.TypeInt,
-				Required:    true,
-			},
 			"resizing_pvc": {
 				Description: "Resizing PVC",
 				Type:        schema.TypeList,
@@ -303,7 +298,6 @@ func (c *ClusterResource) read(ctx context.Context, d *schema.ResourceData, meta
 	utils.SetOrPanic(d, "cloud_provider", cluster.Provider)
 	utils.SetOrPanic(d, "read_only_connections", cluster.ReadOnlyConnections)
 	utils.SetOrPanic(d, "region", cluster.Region)
-	utils.SetOrPanic(d, "replicas", cluster.Replicas)
 	utils.SetOrPanic(d, "storage", cluster.Storage)
 	utils.SetOrPanic(d, "resizing_pvc", cluster.ResizingPvc)
 	utils.SetOrPanic(d, "cluster_id", cluster.ClusterId)


### PR DESCRIPTION
This PR address two issues:

- Add resource example for EHA cluster
- Remove deprecated `replicas`