### PR TITLE
Fix failure of `terraform init` running under the examples/cluster_resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,17 @@ Terraform can be configured by adding the following to your ~/.terraformrc file.
 
 ```hcl
 provider_installation {
-  dev_overrides {
-      "registry.terraform.io/EnterpriseDB/biganimal" = "/Users/<YOUR_HOME>/.terraform.d/plugins/EnterpriseDB/biganimal/0.1.0/<OS_ARCH>"
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. Until terraform-provider-biganimal is registered 
+  # in the terraform registry, we can use a filesystem_mirror.
+  filesystem_mirror {
+    path    = "/Users/<YOUR_HOME>/.terraform.d/plugins"
+    include = ["registry.terraform.io/hashicorp/biganimal"]
   }
 
-  # For all other providers, install them directly from their origin provider
-  # registries as normal. If you omit this, Terraform will _only_ use
-  # the dev_overrides block, and so no other providers will be available.
-  direct {}
+  direct {
+    exclude = ["registry.terraform.io/hashicorp/biganimal"]
+  }
 }
 ```
 


### PR DESCRIPTION
this PR is to fix the issue https://github.com/EnterpriseDB/terraform-provider-biganimal/issues/40, through make use of [Explicit installation method](https://developer.hashicorp.com/terraform/cli/config/config-file#explicit-installation-method-configuration).

```sh
➜  cluster_resource git:(dev/40) ✗  terraform init  

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/random versions matching "3.3.1"...
- Finding hashicorp/biganimal versions matching "0.3.1"...
- Installing hashicorp/random v3.3.1...
- Installed hashicorp/random v3.3.1 (signed by HashiCorp)
- Installing hashicorp/biganimal v0.3.1...
- Installed hashicorp/biganimal v0.3.1 (unauthenticated)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp.com/edu/hashicups-pf in /Users/huyantian/go/bin
│  - hashicorp/biganimal in /Users/huyantian/.terraform.d/plugins/hashicorp.com/edu/biganimal/0.3.1/darwin_amd64
│ 
│ Skip terraform init when using provider development overrides. It is not necessary and may error unexpectedly.
╵

╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file checksums locally for the following providers:
│   - hashicorp/biganimal
│ 
│ The current .terraform.lock.hcl file only includes checksums for darwin_amd64, so Terraform running on another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

```
