### PR TITLE
docs: Correct the token variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ provider_installation {
 }
 ```
 
-Now, you can configure your BigAnimal provider. This can be done in 2 ways:
+Now, you can configure your BigAnimal provider. This can be done in one of these two ways:
 
 ### Providing BigAnimal configuration in a provider block
 ```hcl

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ see [Getting started with the BigAnimal free trial.](https://www.enterprisedb.co
 ```terraform
 # Configure the BigAnimal Provider
 provider "biganimal" {
-  ba_token = "<redacted>"
+  ba_bearer_token = "<redacted>"
   //ba_api_uri   = "https://portal.biganimal.com/api/v2" // Optional
 }
 # Manage the resources

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,6 +1,6 @@
 # Configure the BigAnimal Provider
 provider "biganimal" {
-  ba_token = "<redacted>"
+  ba_bearer_token = "<redacted>"
   //ba_api_uri   = "https://portal.biganimal.com/api/v2" // Optional
 }
 # Manage the resources


### PR DESCRIPTION
We standardized the provider block parameter `ba_bearer_token` and the env var name `BA_BEARER_TOKEN` in #84 , but 
I forgot to update the examples. 

This PR fixes the example and the documentation. 

Please review. 