### PR TITLE
ci: Prepare for the release

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,10 +1,9 @@
 
 TEST?=$$(go list ./... | grep -v 'vendor')
-HOSTNAME=hashicorp.com
-NAMESPACE=edu
+HOSTNAME=EnterpriseDB
 NAME=biganimal
 BINARY=terraform-provider-${NAME}
-VERSION=0.3.1
+VERSION=0.1.0
 
 # Figure out the OS and ARCH of the
 # builder machine
@@ -36,8 +35,8 @@ release:
 	goreleaser release --rm-dist --snapshot --skip-publish  --skip-sign
 
 install: build
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
-	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAME}/${VERSION}/${OS_ARCH}
 
 test:
 	go test -i $(TEST) || exit 1

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Builds are done via make targets.  Running `make` will build and install the pro
 ```bash
 $ make
 go build -o terraform-provider-biganimal
-mkdir -p ~/.terraform.d/plugins/hashicorp.com/edu/biganimal/0.3.1/darwin_amd64
-mv terraform-provider-biganimal ~/.terraform.d/plugins/hashicorp.com/edu/biganimal/0.3.1/darwin_amd64
+mkdir -p ~/.terraform.d/plugins/EnterpriseDB/biganimal/0.1.0/darwin_amd64
+mv terraform-provider-biganimal ~/.terraform.d/plugins/EnterpriseDB/biganimal/0.1.0/darwin_amd64
 ```
 
 The binary can also be compiled by `go build`, which will output the binary into the current directory.
@@ -38,7 +38,7 @@ Terraform can be configured by adding the following to your ~/.terraformrc file.
 ```hcl
 provider_installation {
   dev_overrides {
-      "registry.terraform.io/hashicorp/biganimal" = "/Users/<YOUR_HOME>/.terraform.d/plugins/hashicorp.com/edu/biganimal/0.3.1/<OS_ARCH>"
+      "registry.terraform.io/EnterpriseDB/biganimal" = "/Users/<YOUR_HOME>/.terraform.d/plugins/EnterpriseDB/biganimal/0.1.0/<OS_ARCH>"
   }
 
   # For all other providers, install them directly from their origin provider
@@ -101,13 +101,13 @@ If you're using Vscode, you can use the embedded Golang Debugger. Intro to debug
 There is already a .vscode/launch.json file, so you can easily run `Debug - Attach External CLI` in the Run and Debug section, which is going to print a `TF_REATTACH_PROVIDERS` env var if your code builds successfully. The env var looks similar to this one:
 
 ```bash
-$> TF_REATTACH_PROVIDERS='{"registry.terraform.io/hashicorp/biganimal":{"Protocol":"grpc","ProtocolVersion":5,"Pid":14123,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/99/kt3b7rgn7wbcc55jt9zv_rch0000gn/T/plugin608643082"}}}'
+$> TF_REATTACH_PROVIDERS='{"registry.terraform.io/EnterpriseDB/biganimal":{"Protocol":"grpc","ProtocolVersion":5,"Pid":14123,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/99/kt3b7rgn7wbcc55jt9zv_rch0000gn/T/plugin608643082"}}}'
 ```
 
-You can navigate to `examples/provider` directory and run your terraform commands with this env var:
+You can navigate to the folders under `examples/` directory and run your terraform commands with this env var:
 
 ```bash
-$> TF_REATTACH_PROVIDERS='{"registry.terraform.io/hashicorp/biganimal":{"Protocol":"grpc","ProtocolVersion":5,"Pid":14123,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/99/kt3b7rgn7wbcc55jt9zv_rch0000gn/T/plugin608643082"}}}' terraform plan
+$> TF_REATTACH_PROVIDERS='{"registry.terraform.io/EnterpriseDB/biganimal":{"Protocol":"grpc","ProtocolVersion":5,"Pid":14123,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/99/kt3b7rgn7wbcc55jt9zv_rch0000gn/T/plugin608643082"}}}' terraform plan
 ```
 
 For more information about Vscode Golang debugging, please refer to [this documentation](https://github.com/golang/vscode-go/blob/master/docs/debugging.md).

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -86,7 +86,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -168,7 +168,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -8,7 +8,7 @@ The cluster resource is used to manage BigAnimal clusters. See [Creating a clust
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
     random = {
@@ -85,7 +85,7 @@ output "password" {
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
     random = {
@@ -167,7 +167,7 @@ output "ro_connection_uri" {
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
     random = {

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -8,7 +8,7 @@ The region resource is used to manage regions for a given cloud provider. See [A
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
   }

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
   }
 }

--- a/examples/data-sources/biganimal_cluster/provider.tf
+++ b/examples/data-sources/biganimal_cluster/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
   }

--- a/examples/data-sources/biganimal_cluster/provider.tf
+++ b/examples/data-sources/biganimal_cluster/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
   }
 }

--- a/examples/data-sources/biganimal_region/provider.tf
+++ b/examples/data-sources/biganimal_region/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
   }

--- a/examples/data-sources/biganimal_region/provider.tf
+++ b/examples/data-sources/biganimal_region/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
   }
 }

--- a/examples/resources/biganimal_cluster/eha/resource.tf
+++ b/examples/resources/biganimal_cluster/eha/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
     random = {

--- a/examples/resources/biganimal_cluster/eha/resource.tf
+++ b/examples/resources/biganimal_cluster/eha/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
     random = {

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
     random = {

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_region/resource.tf
+++ b/examples/resources/biganimal_region/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     biganimal = {
-      source  = "biganimal"
+      source  = "EnterpriseDB/biganimal"
       version = "0.1.0"
     }
   }

--- a/examples/resources/biganimal_region/resource.tf
+++ b/examples/resources/biganimal_region/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "biganimal"
-      version = "0.3.1"
+      version = "0.1.0"
     }
   }
 }

--- a/main.go
+++ b/main.go
@@ -35,8 +35,7 @@ func main() {
 	opts := &plugin.ServeOpts{
 		Debug: debugMode,
 
-		// TODO: update this string with the full name of your provider as used in your configs
-		ProviderAddr: "registry.terraform.io/hashicorp/biganimal",
+		ProviderAddr: "registry.terraform.io/EnterpriseDB/biganimal",
 
 		ProviderFunc: provider.New(version),
 	}


### PR DESCRIPTION
* Adjust the HOSTNAME variable in GNUmakefile
* Remove the NAMESPACE, not needed
* Update the version to 0.1.0
* Update the source string in docs and examples

To test this change, please ensure that your `~/.terraformrc` file is similar to this:
```
provider_installation {

  direct {
    exclude = ["registry.terraform.io/EnterpriseDB/biganimal"]
  }
  filesystem_mirror {
    path    = "/Users/<username>/.terraform.d/plugins"
    include = ["EnterpriseDB/biganimal"]
  }
}
```
This change will be merged later with #89. This terraformrc hack is needed until we publish the provider to the terraform registry. 