### PR TITLE
docs: Update docs, we actually support creating regions

### DIFF
--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -1,8 +1,6 @@
 # biganimal_region (Resource)
 The region resource is used to manage regions for a given cloud provider. See [Activating regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/) for more details.
 
-!> Creation of region resources is not supported for now.
-
 ## Example Usage
 ```terraform
 terraform {

--- a/templates/resources/region.md.tmpl
+++ b/templates/resources/region.md.tmpl
@@ -1,8 +1,6 @@
 # {{.Name}} ({{.Type}})
 {{ .Description | trimspace }}
 
-!> Creation of region resources is not supported for now.
-
 {{ if .HasExample -}}
 ## Example Usage
 {{ tffile .ExampleFile }}


### PR DESCRIPTION
Because of [the create function of the RegionClient](https://github.com/EnterpriseDB/terraform-provider-biganimal/blob/main/pkg/api/region_client.go#L43) was shown as `Not Implemented`, I thought the creation of region resources was not implemented, that's why this disclaimer was added to the region resource documentation. 

However, `Create` for Region Resource simply [calls the Update function](https://github.com/EnterpriseDB/terraform-provider-biganimal/blob/main/pkg/provider/resource_region.go#L73). In a way, it makes sense because `Create` is `Updating a region with ACTIVE status`. 😅 

So, we do support the creation of regions, thanks to @kunliuedb for pointing that out! 
Updating the documentation accordingly. Please review. 