### PR TITLE
fix: Change api code structure for setting user-agent

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,33 +7,34 @@ import (
 )
 
 type API struct {
-	Url   string
-	Token string
-
-	httpClient *http.Client
+	BaseURL    string
+	Token      string
+	UserAgent  string
+	HTTPClient http.Client
 }
 
-func NewAPI(ba_bearer_token string, ba_api_uri string) *API {
-	httpClient := &http.Client{
+func NewAPI(ba_bearer_token, ba_api_uri, userAgent string) *API {
+	httpClient := http.Client{
 		Timeout: 10 * time.Second,
 	}
 
 	api := &API{
-		ba_api_uri,
-		ba_bearer_token,
-		httpClient,
+		BaseURL:    ba_api_uri,
+		Token:      ba_bearer_token,
+		UserAgent:  userAgent,
+		HTTPClient: httpClient,
 	}
 
 	return api
 }
 
 func (api *API) ClusterClient() *ClusterClient {
-	c := NewClusterClient(api.Url, api.Token)
+	c := NewClusterClient(*api)
 	return c
 }
 
 func (api *API) RegionClient() *RegionClient {
-	c := NewRegionClient(api.Url, api.Token)
+	c := NewRegionClient(*api)
 	return c
 }
 

--- a/pkg/api/cluster_client_test.go
+++ b/pkg/api/cluster_client_test.go
@@ -20,7 +20,7 @@ func init() {
 func TestConnectionString(t *testing.T) {
 	RegisterTestingT(t)
 	defer gock.Off()
-	client := NewClusterClient(testAPIURL, "TOKEN")
+	client := NewClusterClient(API{BaseURL: testAPIURL, Token: "TOKEN"})
 
 	var cases = []struct {
 		id       string

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -2,13 +2,15 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func doRequest(ctx context.Context, c http.Client, httpMethod, url, token string, body io.Reader) ([]byte, error) {
+func (api API) doRequest(ctx context.Context, httpMethod, path string, body io.Reader) ([]byte, error) {
+	var url = fmt.Sprintf("%s/%s", api.BaseURL, path)
 	req, err := http.NewRequest(httpMethod, url, body)
 	if err != nil {
 		return nil, err
@@ -16,11 +18,11 @@ func doRequest(ctx context.Context, c http.Client, httpMethod, url, token string
 
 	tflog.Debug(ctx, url)
 
-	req.Header.Add("user-agent", userAgent)
-	req.Header.Add("authorization", "Bearer "+token)
+	req.Header.Add("user-agent", api.UserAgent)
+	req.Header.Add("authorization", "Bearer "+api.Token)
 	req.Header.Add("content-type", "application/json")
 
-	res, err := c.Do(req)
+	res, err := api.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -33,4 +35,5 @@ func doRequest(ctx context.Context, c http.Client, httpMethod, url, token string
 	}
 
 	return out, err
+
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/EnterpriseDB/terraform-provider-biganimal/pkg/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -75,6 +76,8 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		// api.BuildAPI(meta).ClusterClient()
 		// or
 		// api.BuildAPI(meta).RegionClient()
-		return api.NewAPI(ba_bearer_token, ba_api_uri), nil
+
+		userAgent := fmt.Sprintf("%s/%s", "terraform-provider-biganimal", version)
+		return api.NewAPI(ba_bearer_token, ba_api_uri, userAgent), nil
 	}
 }


### PR DESCRIPTION
to add `user-agent` to the HTTP header, make the following changes

- change `NewXxxClient(ba_bearer_token string, ba_api_uri string)` to ``NewXxxClient(api API)`
- change `doRequest()` called in each methods to `api.doReuqest()`

methods in `XxxClient` don't need to know `token` and `url` 