### PR TITLE
ci: Prepare for the release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
-## 0.1.0 (Unreleased)
+## 0.1.2 (Unreleased)
+
+## 0.1.1 (December 9, 2022)
+
+Enhancements:
+* Better Error Handling: Now we give more details about the errors
+* Better documentation and minor fixes
+* Include terraform version in the User Agent string
+
+## 0.1.0 (November 29, 2022)
+
+Initial version of the terraform provider that includes `biganimal_cluster` and `biganimal_region` data source
+and resources
+
 
 BACKWARDS INCOMPATIBILITIES / NOTES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=EnterpriseDB
 NAME=biganimal
 BINARY=terraform-provider-${NAME}
-VERSION=0.1.0
+VERSION=0.1.1
 
 # Figure out the OS and ARCH of the
 # builder machine

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     biganimal = {
       source = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
   }
 }

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
     random = {
       source  = "hashicorp/random"
@@ -86,7 +86,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
     random = {
       source  = "hashicorp/random"
@@ -168,7 +168,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
   }
 }

--- a/examples/data-sources/biganimal_cluster/provider.tf
+++ b/examples/data-sources/biganimal_cluster/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
   }
 }

--- a/examples/data-sources/biganimal_region/provider.tf
+++ b/examples/data-sources/biganimal_region/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
   }
 }

--- a/examples/resources/biganimal_cluster/eha/resource.tf
+++ b/examples/resources/biganimal_cluster/eha/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_region/resource.tf
+++ b/examples/resources/biganimal_region/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.0"
+      version = "0.1.1"
     }
   }
 }


### PR DESCRIPTION
We don't have an automated Changelog creation mechanism yet, that's why I wanted to start writing the Changelog.md manually for now, to start logging the changes.

This change updates the code to point to the new release. After merging this PR, I'll tag the `v0.1.1` version and start the release process. 

Please review. 

