### PR TITLE
feat: Introduce logs_url and metrics_url to the biganimal_cluster resource/data-sources

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -44,6 +44,14 @@ output "instance_type" {
   value = data.biganimal_cluster.this.instance_type
 }
 
+output "metrics_url" {
+  value = data.biganimal_cluster.this.metrics_url
+}
+
+output "logs_url" {
+  value = data.biganimal_cluster.this.logs_url
+}
+
 output "pg_config" {
   value = data.biganimal_cluster.this.pg_config
 }
@@ -111,6 +119,8 @@ output "storage" {
 - `first_recoverability_point_at` (String) Earliest backup recover time.
 - `id` (String) The ID of this resource.
 - `instance_type` (String) Instance type.
+- `logs_url` (String) The URL to find the logs of this cluster.
+- `metrics_url` (String) The URL to find the metrics of this cluster.
 - `pg_config` (List of Object) Database configuration parameters. (see [below for nested schema](#nestedatt--pg_config))
 - `pg_type` (String) Postgres type.
 - `pg_version` (String) Postgres version.

--- a/examples/data-sources/biganimal_cluster/data-source.tf
+++ b/examples/data-sources/biganimal_cluster/data-source.tf
@@ -39,6 +39,14 @@ output "instance_type" {
   value = data.biganimal_cluster.this.instance_type
 }
 
+output "metrics_url" {
+  value = data.biganimal_cluster.this.metrics_url
+}
+
+output "logs_url" {
+  value = data.biganimal_cluster.this.logs_url
+}
+
 output "pg_config" {
   value = data.biganimal_cluster.this.pg_config
 }

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -48,6 +48,8 @@ func NewCluster(d *schema.ResourceData) (*Cluster, error) {
 		// DeletedAt
 		// ExpiredAt
 		// FirstRecoverabilityPointAt
+		// LogsUrl
+		// MetricsUrl
 		// Phase
 		// ResizingPvc
 
@@ -118,6 +120,8 @@ type Cluster struct {
 	ExpiredAt                  *PointInTime      `json:"expiredAt,omitempty"`
 	FirstRecoverabilityPointAt *PointInTime      `json:"firstRecoverabilityPointAt,omitempty"`
 	InstanceType               *InstanceType     `json:"instanceType,omitempty"`
+	LogsUrl                    *string           `json:"logsUrl,omitempty"`
+	MetricsUrl                 *string           `json:"metricsUrl,omitempty"`
 	Password                   *string           `json:"password,omitempty"`
 	PgConfig                   *[]KeyValue       `json:"pgConfig,omitempty"`
 	PgType                     *PgType           `json:"pgType,omitempty"`

--- a/pkg/provider/data_source_cluster.go
+++ b/pkg/provider/data_source_cluster.go
@@ -101,6 +101,16 @@ func (c *ClusterData) Schema() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"logs_url": {
+				Description: "The URL to find the logs of this cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"metrics_url": {
+				Description: "The URL to find the metrics of this cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"cluster_id": {
 				Description: "Cluster ID.",
 				Type:        schema.TypeString,
@@ -252,6 +262,8 @@ func (c *ClusterData) Read(ctx context.Context, d *schema.ResourceData, meta any
 	utils.SetOrPanic(d, "cluster_name", cluster.ClusterName)
 	utils.SetOrPanic(d, "first_recoverability_point_at", cluster.FirstRecoverabilityPointAt)
 	utils.SetOrPanic(d, "instance_type", cluster.InstanceType)
+	utils.SetOrPanic(d, "logs_url", cluster.LogsUrl)
+	utils.SetOrPanic(d, "metrics_url", cluster.MetricsUrl)
 	utils.SetOrPanic(d, "pg_config", cluster.PgConfig)
 	utils.SetOrPanic(d, "pg_type", cluster.PgType)
 	utils.SetOrPanic(d, "pg_version", cluster.PgVersion)

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -295,6 +295,8 @@ func (c *ClusterResource) read(ctx context.Context, d *schema.ResourceData, meta
 	utils.SetOrPanic(d, "cluster_name", cluster.ClusterName)
 	utils.SetOrPanic(d, "first_recoverability_point_at", cluster.FirstRecoverabilityPointAt)
 	utils.SetOrPanic(d, "instance_type", cluster.InstanceType)
+	utils.SetOrPanic(d, "logs_url", cluster.LogsUrl)
+	utils.SetOrPanic(d, "metrics_url", cluster.MetricsUrl)
 	utils.SetOrPanic(d, "pg_config", cluster.PgConfig)
 	utils.SetOrPanic(d, "pg_type", cluster.PgType)
 	utils.SetOrPanic(d, "pg_version", cluster.PgVersion)


### PR DESCRIPTION
With this change, the cluster data sources will be able to read the logs and metrics URLs.
Because they are computed fields, we're not reading values for those fields while creating a cluster. 

Please review. 