### PR TITLE
ci: Update the version strings for the 0.1.2 release.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=EnterpriseDB
 NAME=biganimal
 BINARY=terraform-provider-${NAME}
-VERSION=0.1.1
+VERSION=0.1.2
 
 # Figure out the OS and ARCH of the
 # builder machine

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     biganimal = {
       source = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
   }
 }

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"
@@ -87,7 +87,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"
@@ -169,7 +169,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
   }
 }

--- a/examples/data-sources/biganimal_cluster/provider.tf
+++ b/examples/data-sources/biganimal_cluster/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
   }
 }

--- a/examples/data-sources/biganimal_region/provider.tf
+++ b/examples/data-sources/biganimal_region/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
   }
 }

--- a/examples/resources/biganimal_cluster/eha/resource.tf
+++ b/examples/resources/biganimal_cluster/eha/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/single_node/aws/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/aws/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/single_node/azure/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/azure/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/biganimal_region/resource.tf
+++ b/examples/resources/biganimal_region/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     biganimal = {
       source  = "EnterpriseDB/biganimal"
-      version = "0.1.1"
+      version = "0.1.2"
     }
   }
 }


### PR DESCRIPTION
Release announcement for v0.1.2
```
v0.1.2 (January 10, 2023)

Enhancements:
* New fields are added to biganimal_cluster resource and data-sources
 - csp_auth field for IAM authentication in AWS
 - logs_url and metrics_url fields
* Various dependency updates
* GitHub Issue Templates are updated.
```
After the merge of this PR, I'm going to tag the release.
Please review. 