### PR TITLE
feat: Adapt to BigAnimal APIv3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-export BA_API_URI="https://portal.biganimal.com/api/v2"
-#export TF_LOG_PROVIDER=DEBUG

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ terraform {
 provider "biganimal" {
   # Configuration options
     ba_bearer_token = <redacted> // See Getting an API Token section for details
-  // ba_api_uri   = "https://portal.biganimal.com/api/v2" // Optional
+  // ba_api_uri   = "https://portal.biganimal.com/api/v3" // Optional
 }
 ```
 
@@ -41,7 +41,7 @@ You can also set the `BA_BEARER_TOKEN` and `BA_API_URI` env vars. When those env
 
 ```bash
 export BA_BEARER_TOKEN=<redacted>
-export BA_API_URI=https://portal.biganimal.com/api/v2
+export BA_API_URI=https://portal.biganimal.com/api/v3
 ```
 
 ### Getting an API Token

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -11,6 +11,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 data "biganimal_cluster" "this" {

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -8,8 +8,14 @@ variable "cluster_name" {
   description = "The name of the cluster"
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 data "biganimal_cluster" "this" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 }
 
 output "cluster_architecture" {
@@ -103,6 +109,7 @@ output "storage" {
 ### Required
 
 - `cluster_name` (String) Name of the cluster.
+- `project_id` (String) BigAnimal Project ID.
 
 ### Read-Only
 

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -11,11 +11,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 data "biganimal_cluster" "this" {

--- a/docs/data-sources/region.md
+++ b/docs/data-sources/region.md
@@ -13,8 +13,14 @@ variable "cloud_provider" {
   }
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 data "biganimal_region" "this" {
   cloud_provider = var.cloud_provider
+  project_id     = var.project_id
   // region_id   = "us-west-1" //optional
   // query       = "eu" // optional
 }
@@ -34,6 +40,7 @@ output "cloud_provider_id" {
 ### Required
 
 - `cloud_provider` (String) Cloud provider to list the regions. For example, "aws" or "azure".
+- `project_id` (String) BigAnimal Project ID.
 
 ### Optional
 

--- a/docs/data-sources/region.md
+++ b/docs/data-sources/region.md
@@ -17,10 +17,6 @@ variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
 
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 data "biganimal_region" "this" {

--- a/docs/data-sources/region.md
+++ b/docs/data-sources/region.md
@@ -16,6 +16,11 @@ variable "cloud_provider" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 data "biganimal_region" "this" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ see [Getting started with the BigAnimal free trial.](https://www.enterprisedb.co
 # Configure the BigAnimal Provider
 provider "biganimal" {
   ba_bearer_token = "<redacted>"
-  //ba_api_uri   = "https://portal.biganimal.com/api/v2" // Optional
+  //ba_api_uri   = "https://portal.biganimal.com/api/v3" // Optional
 }
 # Manage the resources
 ```

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -32,11 +32,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {
@@ -121,11 +116,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "ha_cluster" {
@@ -213,11 +203,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "eha_cluster" {

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -32,6 +32,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {
@@ -116,6 +121,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "ha_cluster" {
@@ -203,6 +213,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "eha_cluster" {

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -29,8 +29,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 resource "biganimal_cluster" "single_node_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"
@@ -107,9 +113,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
 
 resource "biganimal_cluster" "ha_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"
@@ -189,9 +200,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
 
 resource "biganimal_cluster" "eha_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"
@@ -256,6 +272,7 @@ output "connection_uri" {
 - `password` (String, Sensitive) Password for the user edb_admin. It must be 12 characters or more.
 - `pg_type` (String) Postgres type. For example, "epas", "pgextended", or "postgres".
 - `pg_version` (String) Postgres version. See [Supported Postgres types and versions](https://www.enterprisedb.com/docs/biganimal/latest/overview/05_database_version_policy/#supported-postgres-types-and-versions) for supported Postgres types and versions.
+- `project_id` (String) BigAnimal Project ID.
 - `region` (String) Region to deploy the cluster. See [Supported regions](https://www.enterprisedb.com/docs/biganimal/latest/overview/03a_region_support/) for supported regions.
 - `storage` (Block List, Min: 1) Storage. (see [below for nested schema](#nestedblock--storage))
 
@@ -278,6 +295,8 @@ output "connection_uri" {
 - `expired_at` (String) Cluster expiry time.
 - `first_recoverability_point_at` (String) Earliest backup recover time.
 - `id` (String) The ID of this resource.
+- `logs_url` (String) The URL to find the logs of this cluster.
+- `metrics_url` (String) The URL to find the metrics of this cluster.
 - `phase` (String) Current phase of the cluster.
 - `resizing_pvc` (List of String) Resizing PVC.
 - `ro_connection_uri` (String) Cluster read-only connection URI. Only available for high availability clusters.

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -12,9 +12,15 @@ terraform {
   }
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 resource "biganimal_region" "this" {
   cloud_provider = "aws"
   region_id      = "eu-west-1"
+  project_id     = var.project_id
 }
 
 output "region_status" {
@@ -36,6 +42,7 @@ output "region_continent" {
 ### Required
 
 - `cloud_provider` (String) Cloud provider. For example, "aws" or "azure".
+- `project_id` (String) BigAnimal Project ID.
 - `region_id` (String) Region ID of the region. For example, "germanywestcentral" in the Azure cloud provider or "eu-west-1" in the AWS cloud provider.
 
 ### Optional

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -15,11 +15,6 @@ terraform {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_region" "this" {

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -15,6 +15,11 @@ terraform {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_region" "this" {

--- a/examples/data-sources/biganimal_cluster/data-source.tf
+++ b/examples/data-sources/biganimal_cluster/data-source.tf
@@ -3,8 +3,14 @@ variable "cluster_name" {
   description = "The name of the cluster"
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 data "biganimal_cluster" "this" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 }
 
 output "cluster_architecture" {

--- a/examples/data-sources/biganimal_cluster/data-source.tf
+++ b/examples/data-sources/biganimal_cluster/data-source.tf
@@ -6,11 +6,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 data "biganimal_cluster" "this" {

--- a/examples/data-sources/biganimal_cluster/data-source.tf
+++ b/examples/data-sources/biganimal_cluster/data-source.tf
@@ -6,6 +6,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 data "biganimal_cluster" "this" {

--- a/examples/data-sources/biganimal_region/data-source.tf
+++ b/examples/data-sources/biganimal_region/data-source.tf
@@ -11,6 +11,11 @@ variable "cloud_provider" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 data "biganimal_region" "this" {

--- a/examples/data-sources/biganimal_region/data-source.tf
+++ b/examples/data-sources/biganimal_region/data-source.tf
@@ -12,10 +12,6 @@ variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
 
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 data "biganimal_region" "this" {

--- a/examples/data-sources/biganimal_region/data-source.tf
+++ b/examples/data-sources/biganimal_region/data-source.tf
@@ -8,8 +8,14 @@ variable "cloud_provider" {
   }
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 data "biganimal_region" "this" {
   cloud_provider = var.cloud_provider
+  project_id     = var.project_id
   // region_id   = "us-west-1" //optional
   // query       = "eu" // optional
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,6 +1,6 @@
 # Configure the BigAnimal Provider
 provider "biganimal" {
   ba_bearer_token = "<redacted>"
-  //ba_api_uri   = "https://portal.biganimal.com/api/v2" // Optional
+  //ba_api_uri   = "https://portal.biganimal.com/api/v3" // Optional
 }
 # Manage the resources

--- a/examples/resources/biganimal_cluster/eha/resource.tf
+++ b/examples/resources/biganimal_cluster/eha/resource.tf
@@ -25,6 +25,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "eha_cluster" {

--- a/examples/resources/biganimal_cluster/eha/resource.tf
+++ b/examples/resources/biganimal_cluster/eha/resource.tf
@@ -22,9 +22,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
 
 resource "biganimal_cluster" "eha_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"

--- a/examples/resources/biganimal_cluster/eha/resource.tf
+++ b/examples/resources/biganimal_cluster/eha/resource.tf
@@ -25,11 +25,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "eha_cluster" {

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -22,9 +22,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
 
 resource "biganimal_cluster" "ha_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -25,11 +25,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "ha_cluster" {

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -25,6 +25,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "ha_cluster" {

--- a/examples/resources/biganimal_cluster/single_node/aws/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/aws/resource.tf
@@ -25,11 +25,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {

--- a/examples/resources/biganimal_cluster/single_node/aws/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/aws/resource.tf
@@ -22,8 +22,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 resource "biganimal_cluster" "single_node_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"

--- a/examples/resources/biganimal_cluster/single_node/aws/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/aws/resource.tf
@@ -25,6 +25,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {

--- a/examples/resources/biganimal_cluster/single_node/azure/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/azure/resource.tf
@@ -25,11 +25,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {

--- a/examples/resources/biganimal_cluster/single_node/azure/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/azure/resource.tf
@@ -22,8 +22,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 resource "biganimal_cluster" "single_node_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"

--- a/examples/resources/biganimal_cluster/single_node/azure/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/azure/resource.tf
@@ -25,6 +25,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -25,11 +25,6 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -22,8 +22,14 @@ variable "cluster_name" {
   description = "The name of the cluster."
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 resource "biganimal_cluster" "single_node_cluster" {
   cluster_name = var.cluster_name
+  project_id   = var.project_id
 
   allowed_ip_ranges {
     cidr_block  = "127.0.0.1/32"

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -25,6 +25,11 @@ variable "cluster_name" {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_cluster" "single_node_cluster" {

--- a/examples/resources/biganimal_region/resource.tf
+++ b/examples/resources/biganimal_region/resource.tf
@@ -7,9 +7,15 @@ terraform {
   }
 }
 
+variable "project_id" {
+  type        = string
+  description = "BigAnimal Project ID"
+}
+
 resource "biganimal_region" "this" {
   cloud_provider = "aws"
   region_id      = "eu-west-1"
+  project_id     = var.project_id
 }
 
 output "region_status" {

--- a/examples/resources/biganimal_region/resource.tf
+++ b/examples/resources/biganimal_region/resource.tf
@@ -10,11 +10,6 @@ terraform {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
-
-  validation {
-    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
-    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
-  }
 }
 
 resource "biganimal_region" "this" {

--- a/examples/resources/biganimal_region/resource.tf
+++ b/examples/resources/biganimal_region/resource.tf
@@ -10,6 +10,11 @@ terraform {
 variable "project_id" {
   type        = string
   description = "BigAnimal Project ID"
+
+  validation {
+    condition     = can(regex("^prj_[[:alnum:]]{16}$", var.project_id))
+    error_message = "Please provide a valid name for the project_id, for example: prj_abcdABCD01234567."
+  }
 }
 
 resource "biganimal_region" "this" {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/h2non/gock v1.2.0
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
@@ -35,7 +36,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.6 // indirect

--- a/pkg/api/cluster_client.go
+++ b/pkg/api/cluster_client.go
@@ -23,7 +23,7 @@ func NewClusterClient(api API) *ClusterClient {
 	return &c
 }
 
-func (c ClusterClient) Create(ctx context.Context, model any) (string, error) {
+func (c ClusterClient) Create(ctx context.Context, projectId string, model any) (string, error) {
 	response := struct {
 		Data struct {
 			ClusterId string `json:"clusterId"`
@@ -37,7 +37,8 @@ func (c ClusterClient) Create(ctx context.Context, model any) (string, error) {
 		return "", err
 	}
 
-	body, err := c.doRequest(ctx, http.MethodPost, "clusters", bytes.NewBuffer(b))
+	url := fmt.Sprintf("projects/%s/clusters", projectId)
+	body, err := c.doRequest(ctx, http.MethodPost, url, bytes.NewBuffer(b))
 
 	if err != nil {
 		return "", err
@@ -47,12 +48,12 @@ func (c ClusterClient) Create(ctx context.Context, model any) (string, error) {
 	return response.Data.ClusterId, err
 }
 
-func (c ClusterClient) Read(ctx context.Context, id string) (*models.Cluster, error) {
+func (c ClusterClient) Read(ctx context.Context, projectId, id string) (*models.Cluster, error) {
 	response := struct {
 		Data models.Cluster `json:"data"`
 	}{}
 
-	url := fmt.Sprintf("clusters/%s", id)
+	url := fmt.Sprintf("projects/%s/clusters/%s", projectId, id)
 	body, err := c.doRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return &response.Data, err
@@ -63,12 +64,12 @@ func (c ClusterClient) Read(ctx context.Context, id string) (*models.Cluster, er
 	return &response.Data, err
 }
 
-func (c ClusterClient) ReadByName(ctx context.Context, name string) (*models.Cluster, error) {
+func (c ClusterClient) ReadByName(ctx context.Context, projectId, name string) (*models.Cluster, error) {
 	clusters := struct {
 		Data []models.Cluster `json:"data"`
 	}{}
 
-	url := fmt.Sprintf("clusters?name=%s", name)
+	url := fmt.Sprintf("projects/%s/clusters?name=%s", projectId, name)
 	body, err := c.doRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return &models.Cluster{}, err
@@ -85,12 +86,12 @@ func (c ClusterClient) ReadByName(ctx context.Context, name string) (*models.Clu
 	return &clusters.Data[0], err
 }
 
-func (c ClusterClient) ConnectionString(ctx context.Context, id string) (*models.ClusterConnection, error) {
+func (c ClusterClient) ConnectionString(ctx context.Context, projectId, id string) (*models.ClusterConnection, error) {
 	response := struct {
 		Data models.ClusterConnection `json:"data"`
 	}{}
 
-	url := fmt.Sprintf("clusters/%s/connection/", id)
+	url := fmt.Sprintf("projects/%s/clusters/%s/connection/", projectId, id)
 	body, err := c.doRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return &models.ClusterConnection{}, err
@@ -102,14 +103,14 @@ func (c ClusterClient) ConnectionString(ctx context.Context, id string) (*models
 	return &response.Data, nil
 }
 
-func (c ClusterClient) Update(ctx context.Context, cluster *models.Cluster, id string) (*models.Cluster, error) {
+func (c ClusterClient) Update(ctx context.Context, cluster *models.Cluster, projectId, id string) (*models.Cluster, error) {
 	response := struct {
 		Data struct {
 			ClusterId string `json:"clusterId"`
 		} `json:"data"`
 	}{}
 
-	url := fmt.Sprintf("clusters/%s", id)
+	url := fmt.Sprintf("projects/%s/clusters/%s", projectId, id)
 
 	b, err := json.Marshal(cluster)
 	if err != nil {
@@ -125,8 +126,8 @@ func (c ClusterClient) Update(ctx context.Context, cluster *models.Cluster, id s
 	return nil, err
 }
 
-func (c ClusterClient) Delete(ctx context.Context, id string) error {
-	url := fmt.Sprintf("clusters/%s", id)
+func (c ClusterClient) Delete(ctx context.Context, projectId, id string) error {
+	url := fmt.Sprintf("projects/%s/clusters/%s", projectId, id)
 	_, err := c.doRequest(ctx, http.MethodDelete, url, nil)
 	return err
 }

--- a/pkg/api/cluster_client_test.go
+++ b/pkg/api/cluster_client_test.go
@@ -23,13 +23,15 @@ func TestConnectionString(t *testing.T) {
 	client := NewClusterClient(API{BaseURL: testAPIURL, Token: "TOKEN"})
 
 	var cases = []struct {
-		id       string
-		connInfo *models.ClusterConnection
-		code     int
-		err      error
+		id         string
+		project_id string
+		connInfo   *models.ClusterConnection
+		code       int
+		err        error
 	}{
 		{
-			id: "some-id",
+			id:         "some-id",
+			project_id: "prj_prjid123",
 			connInfo: &models.ClusterConnection{
 				PgUri: "postgresql://something",
 			},
@@ -37,16 +39,17 @@ func TestConnectionString(t *testing.T) {
 			err:  nil,
 		},
 		{
-			id:       "some-id",
-			connInfo: &models.ClusterConnection{},
-			code:     404,
-			err:      Error404,
+			id:         "some-id",
+			project_id: "prj_prjid123",
+			connInfo:   &models.ClusterConnection{},
+			code:       404,
+			err:        Error404,
 		},
 	}
 
 	for _, test_case := range cases {
 		gock.New(testAPIURL).
-			Get(fmt.Sprintf("/clusters/%s/connection", test_case.id)).
+			Get(fmt.Sprintf("/projects/%s/clusters/%s/connection", test_case.project_id, test_case.id)).
 			Reply(test_case.code).
 			JSON(struct {
 				Data models.ClusterConnection
@@ -54,7 +57,7 @@ func TestConnectionString(t *testing.T) {
 				Data: *test_case.connInfo,
 			})
 
-		info, err := client.ConnectionString(context.Background(), test_case.id)
+		info, err := client.ConnectionString(context.Background(), test_case.project_id, test_case.id)
 		if test_case.err == nil {
 			Expect(err).To(BeNil())
 		} else {

--- a/pkg/api/region_client.go
+++ b/pkg/api/region_client.go
@@ -34,8 +34,8 @@ func (c RegionClient) Create(ctx context.Context, model any) (string, error) {
 	panic("Create not implemented")
 }
 
-func (c RegionClient) Read(ctx context.Context, csp_id, id string) (*models.Region, error) {
-	regions, err := c.List(ctx, csp_id, id)
+func (c RegionClient) Read(ctx context.Context, project_id, csp_id, id string) (*models.Region, error) {
+	regions, err := c.List(ctx, project_id, csp_id, id)
 	if err != nil {
 		return nil, err
 	}
@@ -48,12 +48,12 @@ func (c RegionClient) Read(ctx context.Context, csp_id, id string) (*models.Regi
 	return nil, errors.New("unable to find a unique region")
 }
 
-func (c RegionClient) List(ctx context.Context, csp_id, query string) ([]*models.Region, error) {
+func (c RegionClient) List(ctx context.Context, project_id, csp_id, query string) ([]*models.Region, error) {
 	response := struct {
 		Data []*models.Region `json:"data"`
 	}{}
 
-	url := fmt.Sprintf("cloud-providers/%s/regions", csp_id)
+	url := fmt.Sprintf("projects/%s/cloud-providers/%s/regions", project_id, csp_id)
 	if query != "" {
 		url += fmt.Sprintf("?q=%s", query)
 	}
@@ -68,8 +68,8 @@ func (c RegionClient) List(ctx context.Context, csp_id, query string) ([]*models
 	return response.Data, err
 }
 
-func (c RegionClient) Update(ctx context.Context, action, csp_id, region_id string) error {
-	url := fmt.Sprintf("cloud-providers/%s/regions/%s", csp_id, region_id)
+func (c RegionClient) Update(ctx context.Context, action, project_id, csp_id, region_id string) error {
+	url := fmt.Sprintf("projects/%s/cloud-providers/%s/regions/%s", project_id, csp_id, region_id)
 
 	switch action {
 	case REGION_ACTIVE:

--- a/pkg/provider/data_source_cluster.go
+++ b/pkg/provider/data_source_cluster.go
@@ -245,10 +245,7 @@ func (c *ClusterData) Read(ctx context.Context, d *schema.ResourceData, meta any
 	if !ok {
 		return diag.FromErr(errors.New("unable to find cluster name"))
 	}
-	projectId, ok := d.Get("project_id").(string)
-	if !ok {
-		return diag.FromErr(errors.New("unable to find a project ID"))
-	}
+	projectId := d.Get("project_id").(string)
 
 	cluster, err := client.ReadByName(ctx, projectId, clusterName)
 	if err != nil {

--- a/pkg/provider/data_source_cluster.go
+++ b/pkg/provider/data_source_cluster.go
@@ -165,6 +165,11 @@ func (c *ClusterData) Schema() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
+			"project_id": {
+				Description: "BigAnimal Project ID.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
 			"cloud_provider": {
 				Description: "Cloud provider.",
 				Type:        schema.TypeString,
@@ -237,16 +242,20 @@ func (c *ClusterData) Read(ctx context.Context, d *schema.ResourceData, meta any
 
 	clusterName, ok := d.Get("cluster_name").(string)
 	if !ok {
-		return diag.FromErr(errors.New("Unable to find cluster name"))
+		return diag.FromErr(errors.New("unable to find cluster name"))
+	}
+	projectId, ok := d.Get("project_id").(string)
+	if !ok {
+		return diag.FromErr(errors.New("unable to find a project ID"))
 	}
 
-	cluster, err := client.ReadByName(ctx, clusterName)
+	cluster, err := client.ReadByName(ctx, projectId, clusterName)
 	if err != nil {
 		return fromBigAnimalErr(err)
 	}
 	tflog.Debug(ctx, pretty.Sprint(cluster))
 
-	connection, err := client.ConnectionString(ctx, *cluster.ClusterId)
+	connection, err := client.ConnectionString(ctx, projectId, *cluster.ClusterId)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/provider/data_source_cluster.go
+++ b/pkg/provider/data_source_cluster.go
@@ -166,9 +166,10 @@ func (c *ClusterData) Schema() *schema.Resource {
 				Computed:    true,
 			},
 			"project_id": {
-				Description: "BigAnimal Project ID.",
-				Type:        schema.TypeString,
-				Required:    true,
+				Description:      "BigAnimal Project ID.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateProjectId,
 			},
 			"cloud_provider": {
 				Description: "Cloud provider.",

--- a/pkg/provider/data_source_region.go
+++ b/pkg/provider/data_source_region.go
@@ -66,6 +66,11 @@ func (r *RegionData) Schema() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"project_id": {
+				Description: "BigAnimal Project ID.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
 			"query": {
 				Description: "Query to filter region list.",
 				Type:        schema.TypeString,
@@ -84,6 +89,8 @@ func (r *RegionData) Read(ctx context.Context, d *schema.ResourceData, meta any)
 	diags := diag.Diagnostics{}
 	client := api.BuildAPI(meta).RegionClient()
 	cloud_provider := d.Get("cloud_provider").(string)
+	projectId := d.Get("project_id").(string)
+
 	query := d.Get("query").(string)
 
 	id, ok := d.Get("region_id").(string)
@@ -91,7 +98,7 @@ func (r *RegionData) Read(ctx context.Context, d *schema.ResourceData, meta any)
 		query = id
 	}
 
-	regions, err := client.List(ctx, cloud_provider, query)
+	regions, err := client.List(ctx, projectId, cloud_provider, query)
 	if err != nil {
 		return fromBigAnimalErr(err)
 	}

--- a/pkg/provider/data_source_region.go
+++ b/pkg/provider/data_source_region.go
@@ -67,9 +67,10 @@ func (r *RegionData) Schema() *schema.Resource {
 				Required:    true,
 			},
 			"project_id": {
-				Description: "BigAnimal Project ID.",
-				Type:        schema.TypeString,
-				Required:    true,
+				Description:      "BigAnimal Project ID.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateProjectId,
 			},
 			"query": {
 				Description: "Query to filter region list.",

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -46,7 +46,7 @@ func New(version string) func() *schema.Provider {
 				"ba_api_uri": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					DefaultFunc: schema.EnvDefaultFunc("BA_API_URI", "https://portal.biganimal.com/api/v2"),
+					DefaultFunc: schema.EnvDefaultFunc("BA_API_URI", "https://portal.biganimal.com/api/v3"),
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -262,10 +262,7 @@ func (c *ClusterResource) Create(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	projectId, ok := d.Get("project_id").(string)
-	if !ok {
-		return diag.FromErr(errors.New("unable to find a project ID"))
-	}
+	projectId := d.Get("project_id").(string)
 
 	clusterId, err := client.Create(ctx, projectId, *cluster)
 	if err != nil {
@@ -296,10 +293,7 @@ func (c *ClusterResource) read(ctx context.Context, d *schema.ResourceData, meta
 	client := api.BuildAPI(meta).ClusterClient()
 
 	clusterId := d.Id()
-	projectId, ok := d.Get("project_id").(string)
-	if !ok {
-		return errors.New("unable to find a project ID")
-	}
+	projectId := d.Get("project_id").(string)
 	cluster, err := client.Read(ctx, projectId, clusterId)
 	if err != nil {
 		return err
@@ -366,11 +360,7 @@ func (c *ClusterResource) Update(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	clusterId := d.Id()
-	projectId, ok := d.Get("project_id").(string)
-	if !ok {
-		return diag.FromErr(errors.New("unable to find a project ID"))
-	}
-
+	projectId := d.Get("project_id").(string)
 	_, err = client.Update(ctx, cluster, projectId, clusterId)
 	if err != nil {
 		return fromBigAnimalErr(err)
@@ -390,10 +380,7 @@ func (c *ClusterResource) Update(ctx context.Context, d *schema.ResourceData, me
 func (c *ClusterResource) Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := api.BuildAPI(meta).ClusterClient()
 	clusterId := d.Id()
-	projectId, ok := d.Get("project_id").(string)
-	if !ok {
-		return diag.FromErr(errors.New("unable to find a project ID"))
-	}
+	projectId := d.Get("project_id").(string)
 	if err := client.Delete(ctx, projectId, clusterId); err != nil {
 		return fromBigAnimalErr(err)
 	}
@@ -403,10 +390,7 @@ func (c *ClusterResource) Delete(ctx context.Context, d *schema.ResourceData, me
 func (c *ClusterResource) retryFunc(ctx context.Context, d *schema.ResourceData, meta any, clusterId string) resource.RetryFunc {
 	client := api.BuildAPI(meta).ClusterClient()
 	return func() *resource.RetryError {
-		projectId, ok := d.Get("project_id").(string)
-		if !ok {
-			return resource.NonRetryableError(fmt.Errorf("unable to find a project ID"))
-		}
+		projectId := d.Get("project_id").(string)
 		cluster, err := client.Read(ctx, projectId, clusterId)
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("error describing instance: %s", err))

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -188,9 +188,10 @@ func (c *ClusterResource) Schema() *schema.Resource {
 				Optional:    true,
 			},
 			"project_id": {
-				Description: "BigAnimal Project ID.",
-				Type:        schema.TypeString,
-				Required:    true,
+				Description:      "BigAnimal Project ID.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateProjectId,
 			},
 			"cloud_provider": {
 				Description: "Cloud provider. For example, \"aws\" or \"azure\".",

--- a/pkg/provider/resource_region.go
+++ b/pkg/provider/resource_region.go
@@ -45,9 +45,10 @@ func (r *RegionResource) Schema() *schema.Resource {
 				Required:    true,
 			},
 			"project_id": {
-				Description: "BigAnimal Project ID.",
-				Type:        schema.TypeString,
-				Required:    true,
+				Description:      "BigAnimal Project ID.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateProjectId,
 			},
 			"region_id": {
 				Description: "Region ID of the region. For example, \"germanywestcentral\" in the Azure cloud provider or \"eu-west-1\" in the AWS cloud provider.",

--- a/pkg/provider/resource_region.go
+++ b/pkg/provider/resource_region.go
@@ -44,6 +44,11 @@ func (r *RegionResource) Schema() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"project_id": {
+				Description: "BigAnimal Project ID.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
 			"region_id": {
 				Description: "Region ID of the region. For example, \"germanywestcentral\" in the Azure cloud provider or \"eu-west-1\" in the AWS cloud provider.",
 				Type:        schema.TypeString,
@@ -82,10 +87,11 @@ func (r *RegionResource) Read(ctx context.Context, d *schema.ResourceData, meta 
 
 func (r *RegionResource) read(ctx context.Context, d *schema.ResourceData, meta any) error {
 	client := api.BuildAPI(meta).RegionClient()
+	projectId := d.Get("project_id").(string)
 	cloud_provider := d.Get("cloud_provider").(string)
 
 	id := d.Get("region_id").(string)
-	region, err := client.Read(ctx, cloud_provider, id)
+	region, err := client.Read(ctx, projectId, cloud_provider, id)
 	if err != nil {
 		return err
 	}
@@ -103,9 +109,10 @@ func (r *RegionResource) Update(ctx context.Context, d *schema.ResourceData, met
 
 	cloudProvider := d.Get("cloud_provider").(string)
 	id := d.Get("region_id").(string)
+	projectId := d.Get("project_id").(string)
 	desiredState := d.Get("status").(string)
 
-	region, err := client.Read(ctx, cloudProvider, id)
+	region, err := client.Read(ctx, projectId, cloudProvider, id)
 	if err != nil {
 		return fromBigAnimalErr(err)
 	}
@@ -120,7 +127,7 @@ func (r *RegionResource) Update(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("updating region from %s to %s", region.Status, desiredState))
-	if err = client.Update(ctx, desiredState, cloudProvider, id); err != nil {
+	if err = client.Update(ctx, desiredState, projectId, cloudProvider, id); err != nil {
 		return fromBigAnimalErr(err)
 	}
 
@@ -138,10 +145,11 @@ func (r *RegionResource) Update(ctx context.Context, d *schema.ResourceData, met
 func (r *RegionResource) Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := api.BuildAPI(meta).RegionClient()
 
+	projectId := d.Get("project_id").(string)
 	cloudProvider := d.Get("cloud_provider").(string)
 	id := d.Get("region_id").(string)
 	desiredState := api.REGION_INACTIVE
-	if err := client.Update(ctx, api.REGION_INACTIVE, cloudProvider, id); err != nil {
+	if err := client.Update(ctx, api.REGION_INACTIVE, projectId, cloudProvider, id); err != nil {
 		return fromBigAnimalErr(err)
 	}
 
@@ -160,13 +168,14 @@ func (r *RegionResource) Delete(ctx context.Context, d *schema.ResourceData, met
 func (r *RegionResource) retryFunc(ctx context.Context, d *schema.ResourceData, meta any, cloudProvider, regionId, desiredState string) resource.RetryFunc {
 	client := api.BuildAPI(meta).RegionClient()
 	return func() *resource.RetryError {
-		region, err := client.Read(ctx, cloudProvider, regionId)
+		projectId := d.Get("project_id").(string)
+		region, err := client.Read(ctx, projectId, cloudProvider, regionId)
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error describing instance: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("error describing instance: %s", err))
 		}
 
 		if region.Status != desiredState {
-			return resource.RetryableError(errors.New("Operation incomplete"))
+			return resource.RetryableError(errors.New("operation incomplete"))
 		}
 
 		if err := r.read(ctx, d, meta); err != nil {

--- a/pkg/provider/validators.go
+++ b/pkg/provider/validators.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func validateProjectId(v interface{}, path cty.Path) diag.Diagnostics {
+	value := v.(string)
+	var diags diag.Diagnostics
+	//if value != can(regex("^prj_[[:alnum:]]{16}$", value)) {
+	matched, _ := regexp.MatchString("^prj_[0-9A-Za-z_]{16}$", value)
+	if !matched {
+		diag := diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "invalid value for variable",
+			Detail:   fmt.Sprintf("%q is not valid. Please provide a valid name for the project_id, for example: prj_abcdABCD01234567.", value),
+		}
+		diags = append(diags, diag)
+	}
+	return diags
+}

--- a/pkg/provider/validators_test.go
+++ b/pkg/provider/validators_test.go
@@ -1,0 +1,31 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+func Test_validateProjectId(t *testing.T) {
+	v := "prj_abcdABCD01234567"
+	if diags := validateProjectId(v, *new(cty.Path)); len(diags) != 0 {
+		t.Fatalf("%q should be prj_abcdABCD01234567", v)
+	}
+
+	bad_names := []string{
+		"BAD",                    // Obviously silly
+		"Prj_something",          // Capital letter
+		"prj_ab^dABCD01234567",   // Symbol
+		"prj_abcdABCD0123",       // Too short
+		"prj_abcdABCD0123456789", // Too long
+		"p_abcdABCD01234567",     // Doesn't start with prj_
+		"prjabcdABCD01234567",    // No `_` after prj
+	}
+
+	for _, tt := range bad_names {
+		if diags := validateProjectId(tt, *new(cty.Path)); len(diags) == 0 {
+			t.Fatalf("%q should NOT be prj_abcdABCD01234567", v)
+		}
+	}
+
+}


### PR DESCRIPTION
The PR looks good to go. 

I've created single_node clusters on AWS and Azure, EHA and HA clusters on AWS, and they all looked fine. 
Regions look good to go as well. 

With this PR, we introduce the `validators.go`. It's quite straightforward for a single field validation, which can be used later to accomplish the #85. 

It also contains a fix about the logs_url and metrics_url for the clusters. 

Please review. 