### PR TITLE
docs: Minor readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ provider_installation {
   # verifications for this provider and forces Terraform to look for the
   # null provider plugin in the given directory.
   dev_overrides {
-      "registry.terraform.io/EnterpriseDB/biganimal" = "/home/developer/tmp/terraform-provider-biganimal"
+      "registry.terraform.io/EnterpriseDB/biganimal" = "/home/<YOUR_HOME>/tmp/terraform-provider-biganimal"
   }
 
   # For all other providers, install them directly from their origin provider
@@ -83,7 +83,7 @@ provider_installation {
     exclude = ["registry.terraform.io/EnterpriseDB/biganimal"]
   }
   filesystem_mirror {
-    path    = "/Users/developer/.terraform.d/plugins"
+    path    = "/Users/<YOUR_HOME>/.terraform.d/plugins"
     include = ["registry.terraform.io/EnterpriseDB/biganimal"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ provider_installation {
   direct {}
 }
 ```
+### filesystem mirror
+Another way to test the local code is using the filesystem_mirror declaration in your `~/.terraformrc` file.
+After you compile and install your local copy with the `make install` command, the following ~/.terraformrc` configuration allows you to declare installation path explicitly.
+```
+provider_installation {
+
+  direct {
+    exclude = ["registry.terraform.io/EnterpriseDB/biganimal"]
+  }
+  filesystem_mirror {
+    path    = "/Users/developer/.terraform.d/plugins"
+    include = ["registry.terraform.io/EnterpriseDB/biganimal"]
+  }
+}
+```
+For more info about `filesystem_mirror`, please visit [Terraform Documentation of `Explicit Installation Method Configuration`](https://developer.hashicorp.com/terraform/cli/config/config-file#explicit-installation-method-configuration)
 
 ### Debugging the provider
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,5 +10,7 @@ The document generation tool looks for files in the following locations by defau
 
 ## biganimal_cluster resource examples
 * [Single node cluster example](./resources/biganimal_cluster/single_node/resource.tf)
+  * [Single node cluster example on AWS](./resources/biganimal_cluster/single_node/aws/resource.tf)
+  * [Single node cluster example on Azure](./resources/biganimal_cluster/single_node/azure/resource.tf)
 * [High availability cluster example](./resources/biganimal_cluster/ha/resource.tf)
 * [Extreme high availability cluster example](./resources/biganimal_cluster/eha/resource.tf)


### PR DESCRIPTION
* Documentation for the `filesystem_mirror` way of provider development
* Add links for the AWS and Azure examples of the Single node. 

Please review. 