### PR TITLE
fix: Make allowedIpRanges and pgConfig TypeSet

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -121,7 +121,7 @@ output "faraway_replica_ids" {
 
 ### Read-Only
 
-- `allowed_ip_ranges` (Block List) Allowed IP ranges. (see [below for nested schema](#nestedblock--allowed_ip_ranges))
+- `allowed_ip_ranges` (Block Set) Allowed IP ranges. (see [below for nested schema](#nestedblock--allowed_ip_ranges))
 - `backup_retention_period` (String) Backup retention period.
 - `cloud_provider` (String) Cloud provider.
 - `cluster_architecture` (Block List) Cluster architecture. (see [below for nested schema](#nestedblock--cluster_architecture))
@@ -138,7 +138,7 @@ output "faraway_replica_ids" {
 - `instance_type` (String) Instance type.
 - `logs_url` (String) The URL to find the logs of this cluster.
 - `metrics_url` (String) The URL to find the metrics of this cluster.
-- `pg_config` (List of Object) Database configuration parameters. (see [below for nested schema](#nestedatt--pg_config))
+- `pg_config` (Set of Object) Database configuration parameters. (see [below for nested schema](#nestedatt--pg_config))
 - `pg_type` (String) Postgres type.
 - `pg_version` (String) Postgres version.
 - `phase` (String) Current phase of the cluster.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -287,10 +287,10 @@ output "connection_uri" {
 
 ### Optional
 
-- `allowed_ip_ranges` (Block List) Allowed IP ranges. (see [below for nested schema](#nestedblock--allowed_ip_ranges))
+- `allowed_ip_ranges` (Block Set) Allowed IP ranges. (see [below for nested schema](#nestedblock--allowed_ip_ranges))
 - `backup_retention_period` (String) Backup retention period. For example, "7d", "2w", or "3m".
 - `csp_auth` (Boolean) Is authentication handled by the cloud service provider. Available for AWS only, See [Authentication](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/#authentication) for details.
-- `pg_config` (Block List) Database configuration parameters. See [Modifying database configuration parameters](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters/) for details. (see [below for nested schema](#nestedblock--pg_config))
+- `pg_config` (Block Set) Database configuration parameters. See [Modifying database configuration parameters](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters/) for details. (see [below for nested schema](#nestedblock--pg_config))
 - `private_networking` (Boolean) Is private networking enabled.
 - `read_only_connections` (Boolean) Is read only connection enabled.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -23,7 +23,8 @@ func NewCluster(d *schema.ResourceData) (*Cluster, error) {
 		clusterArchitecture  *Architecture = new(Architecture)
 	)
 
-	allowedIpRanges, err := utils.StructFromProps[[]AllowedIpRange](d.Get("allowed_ip_ranges"))
+	allowedIpRanges, err := utils.StructFromProps[[]AllowedIpRange](d.Get("allowed_ip_ranges").(*schema.Set).List())
+
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +52,7 @@ func NewCluster(d *schema.ResourceData) (*Cluster, error) {
 		}
 	}
 
-	pgConfig, err := utils.StructFromProps[[]KeyValue](d.Get("pg_config"))
+	pgConfig, err := utils.StructFromProps[[]KeyValue](d.Get("pg_config").(*schema.Set).List())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/data_source_cluster.go
+++ b/pkg/provider/data_source_cluster.go
@@ -25,7 +25,7 @@ func (c *ClusterData) Schema() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"allowed_ip_ranges": {
 				Description: "Allowed IP ranges.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -143,7 +143,7 @@ func (c *ClusterData) Schema() *schema.Resource {
 			},
 			"pg_config": {
 				Description: "Database configuration parameters.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -36,7 +36,7 @@ func (c *ClusterResource) Schema() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"allowed_ip_ranges": {
 				Description: "Allowed IP ranges.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -157,7 +157,7 @@ func (c *ClusterResource) Schema() *schema.Resource {
 			},
 			"pg_config": {
 				Description: "Database configuration parameters. See [Modifying database configuration parameters](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters/) for details.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
These changes are taken out of #123, and they will fix #98. 

As explained [in this comment](https://github.com/EnterpriseDB/terraform-provider-biganimal/pull/123#issuecomment-1412116738), they're breaking changes that demand a major bump. 

That's why I would like to keep this PR here and merge it before a major bump (unless we decide to break the API while we still don't have many active users that would be affected from this change) 