### PR TITLE
style: add vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ terraform.tfvars
 *.iml
 .dccache
 website/vendor
+vendor/
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate


### PR DESCRIPTION
We're not using any vendor directory. In order to prevent adding it mistakenly, let's add vendor to gitignore. Please review.