### PR TITLE
ci: Trigger workflows only once in PRs

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -2,7 +2,6 @@ name: conventional-commits
 
 on:
   pull_request:
-    types: [assigned, edited, opened, synchronize, reopened]
 
 jobs:
   commit-compliance:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,9 +2,7 @@ name: Pre-Commit
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
+    types: [assigned, edited, opened, synchronize, reopened]
   workflow_dispatch:
   push:
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,6 @@ name: Pre-Commit
 
 on:
   pull_request:
-    types: [assigned, edited, opened, synchronize, reopened]
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,8 @@ on:
     types: [assigned, edited, opened, synchronize, reopened]
   workflow_dispatch:
   push:
+    branches:
+      - main
 
 env:
   GOLANGCI_LINT_VERSION: "v1.50.1"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    types: [assigned, edited, opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -2,9 +2,7 @@ name: spellcheck-woke
 on:
   push:
   pull_request:
-    types:
-      - opened
-      - synchronize
+    types: [assigned, edited, opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,8 @@
 name: spellcheck-woke
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [assigned, edited, opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,7 @@
 name: Tests
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
+    types: [assigned, edited, opened, synchronize, reopened]
     paths-ignore:
       - 'README.md'
       - '.github/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
       - 'README.md'
       - '.github/**'
   push:
+    branches:
+      - main
     paths-ignore:
       - 'README.md'
   # For systems with an upstream API that could drift unexpectedly (like most SaaS systems, etc.),

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@
 name: Tests
 on:
   pull_request:
-    types: [assigned, edited, opened, synchronize, reopened]
     paths-ignore:
       - 'README.md'
       - '.github/**'


### PR DESCRIPTION
Seen in @edbamolvyavahare 's [PR](https://github.com/EnterpriseDB/terraform-provider-biganimal/pull/149), some workflows were running twice, both on push and pull_request. 

![Screenshot 2023-03-23 at 17 11 43](https://user-images.githubusercontent.com/121254/227272462-e96dede5-9634-4145-a011-bcfb4abbf312.png)

This PR should fix that. Please review.

From[ the documentation of pull_request event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request):
```
By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. 
```
Thus, I removed the event triggers for `pull_request` in the WFs.