### PR TITLE
docs: Mostly whitespace changes in the docs

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1,4 +1,5 @@
 # biganimal_cluster (Resource)
+
 The cluster resource is used to manage BigAnimal clusters. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/) for more details.
 
 

--- a/docs/resources/region.md
+++ b/docs/resources/region.md
@@ -1,7 +1,9 @@
 # biganimal_region (Resource)
+
 The region resource is used to manage regions for a given cloud provider. See [Activating regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/) for more details.
 
 ## Example Usage
+
 ```terraform
 terraform {
   required_providers {

--- a/templates/resources/cluster.md.tmpl
+++ b/templates/resources/cluster.md.tmpl
@@ -1,8 +1,10 @@
 # {{.Name}} ({{.Type}})
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}
 ## Example Usage
+
 {{ tffile .ExampleFile }}
 {{- end }}
 
@@ -19,6 +21,8 @@
 {{- if .HasImport }}
 
 ## Import
+
 Import is supported using the following syntax:
+
 {{ codefile "shell" .ImportFile }}
 {{- end }}

--- a/templates/resources/region.md.tmpl
+++ b/templates/resources/region.md.tmpl
@@ -1,8 +1,10 @@
 # {{.Name}} ({{.Type}})
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}
 ## Example Usage
+
 {{ tffile .ExampleFile }}
 {{- end }}
 
@@ -10,6 +12,8 @@
 {{- if .HasImport }}
 
 ## Import
+
 Import is supported using the following syntax:
+
 {{ codefile "shell" .ImportFile }}
 {{- end }}


### PR DESCRIPTION
When we're using templates, it's good to keep our code as close to [the upstream code](https://github.com/hashicorp/terraform-plugin-docs/blob/e8f8eb1f6dbb047551ceedd48e7810c6c6661d03/internal/provider/template.go#L217) as possible. 

The template doesn't work, when I use the 
```
{{ printf "{{tffile %q}}" .ExampleFile }}
```
I don't know why. That's why I kept on using 
```
{{ tffile .ExampleFile }}
```
Same goes for 
```
{{ codefile "shell" .ImportFile }}
```
(anyhow, we don't have the import functionality right now, see #88 for details) 