### PR TITLE
fix: reflect TypeSet change to FAR as well

### DIFF
--- a/pkg/provider/data_source_fareplica.go
+++ b/pkg/provider/data_source_fareplica.go
@@ -25,7 +25,7 @@ func (c *FAReplicaData) Schema() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"allowed_ip_ranges": {
 				Description: "Allowed IP ranges.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -139,7 +139,7 @@ func (c *FAReplicaData) Schema() *schema.Resource {
 			},
 			"pg_config": {
 				Description: "Database configuration parameters.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/pkg/provider/resource_fareplica.go
+++ b/pkg/provider/resource_fareplica.go
@@ -36,7 +36,7 @@ func (c *FAReplicaResource) Schema() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"allowed_ip_ranges": {
 				Description: "Allowed IP ranges.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -128,7 +128,7 @@ func (c *FAReplicaResource) Schema() *schema.Resource {
 			},
 			"pg_config": {
 				Description: "Database configuration parameters. See [Modifying database configuration parameters](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters/) for details.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Those changes were forgotten when we merged #128. 
Faraway replicas can not be created with 0.4.1 as of now, so, this bug fix is important 😅 

Please review.