### PR TITLE
fix: Fixed datasource_project panic

### DIFF
--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -6,11 +6,11 @@ type CloudProvider struct {
 }
 
 type Project struct {
-	ProjectId      string           `json:"projectId,omitempty" mapstructure:"project_id"`
-	ProjectName    string           `json:"projectName,omitempty" mapstructure:"name"`
-	UserCount      int              `json:"userCount,omitempty" mapstructure:"user_count"`
-	ClusterCount   int              `json:"clusterCount,omitempty" mapstructure:"cluster_count"`
-	CloudProviders *[]CloudProvider `json:"cloudProviders" mapstructure:"cloud_providers"`
+	ProjectId      string          `json:"projectId,omitempty" mapstructure:"project_id"`
+	ProjectName    string          `json:"projectName,omitempty" mapstructure:"name"`
+	UserCount      int             `json:"userCount,omitempty" mapstructure:"user_count"`
+	ClusterCount   int             `json:"clusterCount,omitempty" mapstructure:"cluster_count"`
+	CloudProviders []CloudProvider `json:"cloudProviders" mapstructure:"cloud_providers"`
 }
 
 // Check the return value, if ProjectName is also needed


### PR DESCRIPTION
Execute `terraform init` and `terraform plan` in the directory `examples/data-sources/biganimal_projects`. After running these commands, I encountered the following panic message.
```
panic: interface conversion: interface {} is *[]models.CloudProvider, not *schema.Set 
```
The issue occurs because the `CloudProviders` field of the `models.Project` is of pointer type, which cannot be parsed into the following `if` statement block.
https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/field_writer_map.go#L300

so the following type of assertion will result in a panic 
https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/field_writer_map.go#L346

