### PR TITLE
fix: Add DataSourceWithConfigure Interface

### DIFF
--- a/pkg/provider/data_source_projects.go
+++ b/pkg/provider/data_source_projects.go
@@ -13,6 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+var (
+	_ datasource.DataSource              = &projectsDataSource{}
+	_ datasource.DataSourceWithConfigure = &projectsDataSource{}
+)
+
 type projectsDataSource struct {
 	client *api.ProjectClient
 }


### PR DESCRIPTION
Let's make it a practice to add the `WithConfigure` Interface for the data sources so that we would be able to ensure that the Configure method is implemented (otherwise, the go linter will complain) 

Please review, thank you. 