### PR TITLE
fix: fix BaAPIUri fetch for the SDKv2 library

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -146,7 +146,7 @@ func checkProviderConfig(data *providerData) (ok bool, summary, detail string) {
 		return false, "Unable to find BA_BEARER_TOKEN", "BA_BEARER_TOKEN cannot be an empty string"
 	}
 
-	if data.BaAPIUri == nil {
+	if data.BaAPIUri == nil || *data.BaAPIUri == "" {
 		url := os.Getenv("BA_API_URI")
 		data.BaAPIUri = &url
 	}


### PR DESCRIPTION
We started using mux, and the tfprotov5 server is upgraded to tfprotov6 and we're muxing the SDKv2 library resources of tfprotov5 server and Framework library resources of tfprotov6.

For the provider configuration that uses the Framework library, checking if the data.BaAPIUri is nil or not is enough. But, for the old library SDKv2, those values are set to empty string if they're not present.

We already have this check for BaBearerToken. This commit adds the same check for the BaAPIUri as well.

Once we completely move to the Framework Library, the `== ""` check for both configuration values can be removed.

Please review.