### PR TITLE
fix: Fix a bug for credential data parsing in tfprotov5 resources

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -71,23 +71,19 @@ func NewSDKProvider(version string) func() *sdkschema.Provider {
 
 func configure(version string, p *sdkschema.Provider) func(context.Context, *sdkschema.ResourceData) (any, diag.Diagnostics) {
 	return func(ctx context.Context, schema *sdkschema.ResourceData) (any, diag.Diagnostics) {
-		ba_bearer_token := schema.Get("ba_bearer_token").(string)
-		ba_api_uri := schema.Get("ba_api_uri").(string)
-		// set our meta to be a new api.API
-		// this can be turned into concrete clients
-		// by
-		// api.BuildAPI(meta).ClusterClient()
-		// or
-		// api.BuildAPI(meta).RegionClient()
+		// If the credential data are provided inside a provider block, get them first
+		// If they are not provided, the schema_* credentials will be empty strings
+		schema_ba_bearer_token := schema.Get("ba_bearer_token").(string)
+		schema_ba_api_uri := schema.Get("ba_api_uri").(string)
 
-		data := &providerData{BaAPIUri: &ba_api_uri, BaBearerToken: &ba_bearer_token}
+		data := &providerData{BaAPIUri: &schema_ba_api_uri, BaBearerToken: &schema_ba_bearer_token}
 		ok, summary, detail := checkProviderConfig(data)
 		if !ok {
 			return nil, diag.Diagnostics{diag.Diagnostic{Severity: diag.Error, Summary: summary, Detail: detail}}
 		}
 
 		userAgent := fmt.Sprintf("%s/%s", "terraform-provider-biganimal", version)
-		return api.NewAPI(ba_bearer_token, ba_api_uri, userAgent), nil
+		return api.NewAPI(*data.BaBearerToken, *data.BaAPIUri, userAgent), nil
 	}
 }
 
@@ -136,6 +132,8 @@ func (b bigAnimalProvider) Configure(ctx context.Context, req provider.Configure
 	resp.DataSourceData = client
 }
 
+// Checks if the providerData is set.
+// If not, checks if the environment variables are set or throws an error
 func checkProviderConfig(data *providerData) (ok bool, summary, detail string) {
 	if data.BaBearerToken == nil || *data.BaBearerToken == "" {
 		token := os.Getenv("BA_BEARER_TOKEN")


### PR DESCRIPTION
We're parsing the data to the `data` variable in this function, but then the return api.NewAPI function uses only the schema data.

In this case, the credentials are not fetched from the env vars for the tfprotov5 a.k.a. SDKv2 resources, such as biganimal_cluster.

because ba_bearer_token and ba_api_uri are not set for the Client, the calls fail, such as

Error: Post "/projects/prj_deadbeef012345667/clusters": unsupported protocol scheme ""

This change fixes the issue.