### PR TITLE
docs: Update EPAS examples to use pg_version 15

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -75,7 +75,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
 
   pg_type               = "epas"
-  pg_version            = "14"
+  pg_version            = "15"
   private_networking    = false
   cloud_provider        = "azure"
   read_only_connections = false
@@ -162,7 +162,7 @@ resource "biganimal_cluster" "ha_cluster" {
   }
 
   pg_type               = "epas"
-  pg_version            = "14"
+  pg_version            = "15"
   private_networking    = false
   cloud_provider        = "aws"
   read_only_connections = true

--- a/docs/resources/faraway_replica.md
+++ b/docs/resources/faraway_replica.md
@@ -146,7 +146,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
 
   pg_type        = "epas"
-  pg_version     = "14"
+  pg_version     = "15"
   cloud_provider = "azure"
   region         = "eastus"
 }

--- a/docs/resources/pgd.md
+++ b/docs/resources/pgd.md
@@ -81,7 +81,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {
@@ -175,7 +175,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {
@@ -229,7 +229,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {
@@ -330,7 +330,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {
@@ -424,7 +424,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {
@@ -478,7 +478,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -66,7 +66,7 @@ resource "biganimal_cluster" "ha_cluster" {
   }
 
   pg_type               = "epas"
-  pg_version            = "14"
+  pg_version            = "15"
   private_networking    = false
   cloud_provider        = "aws"
   read_only_connections = true

--- a/examples/resources/biganimal_cluster/single_node/aws/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/aws/resource.tf
@@ -67,7 +67,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
 
   pg_type               = "epas"
-  pg_version            = "14"
+  pg_version            = "15"
   private_networking    = false
   cloud_provider        = "aws"
   read_only_connections = false

--- a/examples/resources/biganimal_cluster/single_node/azure/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/azure/resource.tf
@@ -67,7 +67,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
 
   pg_type               = "epas"
-  pg_version            = "14"
+  pg_version            = "15"
   private_networking    = false
   cloud_provider        = "azure"
   read_only_connections = false

--- a/examples/resources/biganimal_cluster/single_node/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/resource.tf
@@ -67,7 +67,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
 
   pg_type               = "epas"
-  pg_version            = "14"
+  pg_version            = "15"
   private_networking    = false
   cloud_provider        = "azure"
   read_only_connections = false

--- a/examples/resources/biganimal_faraway_replica/cluster_and_faraway_replica/resource.tf
+++ b/examples/resources/biganimal_faraway_replica/cluster_and_faraway_replica/resource.tf
@@ -46,7 +46,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
 
   pg_type        = "epas"
-  pg_version     = "14"
+  pg_version     = "15"
   cloud_provider = "azure"
   region         = "eastus"
 }

--- a/examples/resources/biganimal_pgd/aws/data_group/resource.tf
+++ b/examples/resources/biganimal_pgd/aws/data_group/resource.tf
@@ -71,7 +71,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {

--- a/examples/resources/biganimal_pgd/aws/data_groups_with_witness_group/resource.tf
+++ b/examples/resources/biganimal_pgd/aws/data_groups_with_witness_group/resource.tf
@@ -71,7 +71,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {
@@ -125,7 +125,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {

--- a/examples/resources/biganimal_pgd/azure/data_group/resource.tf
+++ b/examples/resources/biganimal_pgd/azure/data_group/resource.tf
@@ -71,7 +71,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {

--- a/examples/resources/biganimal_pgd/azure/data_groups_with_witness_group/resource.tf
+++ b/examples/resources/biganimal_pgd/azure/data_groups_with_witness_group/resource.tf
@@ -71,7 +71,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {
@@ -125,7 +125,7 @@ resource "biganimal_pgd" "pgd_cluster" {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {

--- a/pkg/provider/resource_cluster_test.go
+++ b/pkg/provider/resource_cluster_test.go
@@ -80,7 +80,7 @@ func clusterResourceConfig(cluster_name, projectID, region string) string {
   }
 
   pg_type               = "epas"
-  pg_version            = "14"
+  pg_version            = "15"
   private_networking    = false
   cloud_provider        = "aws"
   read_only_connections = false

--- a/pkg/provider/resource_pgd_test.go
+++ b/pkg/provider/resource_pgd_test.go
@@ -82,7 +82,7 @@ func pgdResourceConfig(cluster_name, projectID string) string {
         pg_type_id = "epas"
       }
       pg_version = {
-        pg_version_id = "14"
+        pg_version_id = "15"
       }
       private_networking = false
       cloud_provider = {


### PR DESCRIPTION
Not only the examples, but also the acceptance test files are updated. 

<s>Testing this change now</s> This change is tested in the following scenarios: 

-  Single Node Cluster on AWS
-  Single Node Cluster on Azure
-  HA cluster on Azure
-  Cluster and Faraway Replica from that cluster
-  AWS 1 DG
-  AWS 2 DG 1 WG
-  Azure 1 DG
-  Azure 2 DG 1 WG

Please review. 