### PR TITLE
fix: PGD add group state inconsistent bug

### DIFF
--- a/pkg/models/pgd/terraform/cluster_architecture.go
+++ b/pkg/models/pgd/terraform/cluster_architecture.go
@@ -6,5 +6,5 @@ type ClusterArchitecture struct {
 	ClusterArchitectureId   string       `tfsdk:"cluster_architecture_id"`
 	ClusterArchitectureName types.String `tfsdk:"cluster_architecture_name"`
 	Nodes                   float64      `tfsdk:"nodes"`
-	WitnessNodes            *float64     `tfsdk:"witness_nodes"`
+	WitnessNodes            types.Int64  `tfsdk:"witness_nodes"`
 }

--- a/pkg/plan_modifier/data_group_custom_diff.go
+++ b/pkg/plan_modifier/data_group_custom_diff.go
@@ -52,25 +52,36 @@ func (m customDataGroupDiffModifier) PlanModifySet(ctx context.Context, req plan
 		for _, pDg := range planDgs {
 			planRegion := pDg.(basetypes.ObjectValue).Attributes()["region"]
 			if stateRegion.Equal(planRegion) {
-				// set the unknowns manually mainly for delete group.
-				// if we don't set manually they will be set automatically if you put the state in plan value
-				// and they will be set by plan dg index against state dg index which will be in wrong order
-				// if deleting a group.
+				// set the unknowns manually for delete and add group.
+				// if we don't set manually and it is set the same way as useStateForUnknown,
+				// then when it puts the state in plan value it will be set by plan dg index
+				// against state dg index which will be in wrong order if delete a group.
 				pDgAttrTypes := types.ObjectNull(planDgs[0].(basetypes.ObjectValue).AttributeTypes(ctx))
 				pDgAttrValues := pDg.(basetypes.ObjectValue).Attributes()
-				pDgAttrValues["cluster_name"] = sDg.(basetypes.ObjectValue).Attributes()["cluster_name"]
-				pDgAttrValues["cluster_type"] = sDg.(basetypes.ObjectValue).Attributes()["cluster_type"]
-				pDgAttrValues["conditions"] = sDg.(basetypes.ObjectValue).Attributes()["conditions"]
-				pDgAttrValues["connection_uri"] = sDg.(basetypes.ObjectValue).Attributes()["connection_uri"]
-				pDgAttrValues["created_at"] = sDg.(basetypes.ObjectValue).Attributes()["created_at"]
-				pDgAttrValues["group_id"] = sDg.(basetypes.ObjectValue).Attributes()["group_id"]
-				pDgAttrValues["logs_url"] = sDg.(basetypes.ObjectValue).Attributes()["logs_url"]
-				pDgAttrValues["metrics_url"] = sDg.(basetypes.ObjectValue).Attributes()["metrics_url"]
-				pDgAttrValues["phase"] = sDg.(basetypes.ObjectValue).Attributes()["phase"]
-				pDgAttrValues["resizing_pvc"] = sDg.(basetypes.ObjectValue).Attributes()["resizing_pvc"]
+				sDgAttrValues := sDg.(basetypes.ObjectValue).Attributes()
 
-				pDgStorage := pDg.(basetypes.ObjectValue).Attributes()["storage"].(basetypes.ObjectValue).Attributes()
-				sDgStorage := sDg.(basetypes.ObjectValue).Attributes()["storage"].(basetypes.ObjectValue).Attributes()
+				pDgClusterArch := pDgAttrValues["cluster_architecture"].(basetypes.ObjectValue).Attributes()
+				sDgClusterArch := sDgAttrValues["cluster_architecture"].(basetypes.ObjectValue).Attributes()
+				clusterArchAttrTypes := types.ObjectNull(pDgAttrValues["cluster_architecture"].(basetypes.ObjectValue).AttributeTypes(ctx))
+				ClusterArchAttrValues := pDgClusterArch
+				ClusterArchAttrValues["cluster_architecture_name"] = sDgClusterArch["cluster_architecture_name"]
+				ClusterArchAttrValues["witness_nodes"] = sDgClusterArch["witness_nodes"]
+
+				pDgAttrValues["cluster_architecture"] = types.ObjectValueMust(clusterArchAttrTypes.AttributeTypes(ctx), ClusterArchAttrValues)
+
+				pDgAttrValues["cluster_name"] = sDgAttrValues["cluster_name"]
+				pDgAttrValues["cluster_type"] = sDgAttrValues["cluster_type"]
+				pDgAttrValues["conditions"] = sDgAttrValues["conditions"]
+				pDgAttrValues["connection_uri"] = sDgAttrValues["connection_uri"]
+				pDgAttrValues["created_at"] = sDgAttrValues["created_at"]
+				pDgAttrValues["group_id"] = sDgAttrValues["group_id"]
+				pDgAttrValues["logs_url"] = sDgAttrValues["logs_url"]
+				pDgAttrValues["metrics_url"] = sDgAttrValues["metrics_url"]
+				pDgAttrValues["phase"] = sDgAttrValues["phase"]
+				pDgAttrValues["resizing_pvc"] = sDgAttrValues["resizing_pvc"]
+
+				pDgStorage := pDgAttrValues["storage"].(basetypes.ObjectValue).Attributes()
+				sDgStorage := sDgAttrValues["storage"].(basetypes.ObjectValue).Attributes()
 				storageAttrTypes := types.ObjectNull(pDgAttrValues["storage"].(basetypes.ObjectValue).AttributeTypes(ctx))
 				storageAttrValues := pDgStorage
 				storageAttrValues["iops"] = sDgStorage["iops"]

--- a/pkg/provider/data_source_pgd.go
+++ b/pkg/provider/data_source_pgd.go
@@ -164,7 +164,7 @@ func (p pgdDataSource) Schema(ctx context.Context, req datasource.SchemaRequest,
 									Description: "Node count.",
 									Computed:    true,
 								},
-								"witness_nodes": schema.Float64Attribute{
+								"witness_nodes": schema.Int64Attribute{
 									Description: "Witness nodes count.",
 									Computed:    true,
 								},

--- a/pkg/provider/resource_pgd.go
+++ b/pkg/provider/resource_pgd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
@@ -238,11 +239,11 @@ func (p pgdResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 									Description: "Node count.",
 									Required:    true,
 								},
-								"witness_nodes": schema.Float64Attribute{
+								"witness_nodes": schema.Int64Attribute{
 									Description: "Witness nodes count.",
 									Computed:    true,
-									PlanModifiers: []planmodifier.Float64{
-										float64planmodifier.UseStateForUnknown(),
+									PlanModifiers: []planmodifier.Int64{
+										int64planmodifier.UseStateForUnknown(),
 									},
 								},
 							},
@@ -631,7 +632,7 @@ func (p pgdResource) Create(ctx context.Context, req resource.CreateRequest, res
 			ClusterArchitectureId:   v.ClusterArchitecture.ClusterArchitectureId,
 			ClusterArchitectureName: clusterArchName,
 			Nodes:                   v.ClusterArchitecture.Nodes,
-			WitnessNodes:            v.ClusterArchitecture.WitnessNodes,
+			WitnessNodes:            utils.ToPointer(float64(v.ClusterArchitecture.WitnessNodes.ValueInt64())),
 		}
 
 		apiDGModel := pgdApi.DataGroup{
@@ -1041,7 +1042,7 @@ func buildTFGroupsAs(ctx context.Context, diags *diag.Diagnostics, state tfsdk.S
 					ClusterArchitectureId:   apiDGModel.ClusterArchitecture.ClusterArchitectureId,
 					ClusterArchitectureName: types.StringPointerValue(apiDGModel.ClusterArchitecture.ClusterArchitectureName),
 					Nodes:                   apiDGModel.ClusterArchitecture.Nodes,
-					WitnessNodes:            apiDGModel.ClusterArchitecture.WitnessNodes,
+					WitnessNodes:            types.Int64Value(int64(*apiDGModel.ClusterArchitecture.WitnessNodes)),
 				}
 
 				// conditions


### PR DESCRIPTION
PGD add data group expects cluster arch witness nodes unknowns. This is reflect a change from the API