### PR TITLE
fix: pg config bug

### DIFF
--- a/pkg/plan_modifier/data_group_custom_diff.go
+++ b/pkg/plan_modifier/data_group_custom_diff.go
@@ -367,6 +367,17 @@ func (m CustomDataGroupDiffModifier) PlanModifySet(ctx context.Context, req plan
 					planMW,
 					stateDgRegion))
 			}
+
+			// pg config
+			planPgConfig := planDg.(basetypes.ObjectValue).Attributes()["pg_config"]
+			statePgConfig := stateDgs[*stateDgKey].(basetypes.ObjectValue).Attributes()["pg_config"]
+
+			if !planPgConfig.Equal(statePgConfig) {
+				resp.Diagnostics.AddWarning("Pg config changed", fmt.Sprintf("Pg config changed from %v to %v for data group with region %v",
+					statePgConfig,
+					planPgConfig,
+					stateDgRegion))
+			}
 		}
 
 	}

--- a/pkg/provider/data_source_pgd.go
+++ b/pkg/provider/data_source_pgd.go
@@ -455,10 +455,15 @@ func (p pgdDataSource) Read(ctx context.Context, req datasource.ReadRequest, res
 	data.ID = cluster.ClusterId
 	data.ClusterID = cluster.ClusterId
 
-	buildTFGroupsAs(ctx, &resp.Diagnostics, resp.State, *cluster, &data.DataGroups, &data.WitnessGroups)
+	buildGroups := PGD{}
+
+	buildTFGroupsAs(ctx, &resp.Diagnostics, resp.State, *cluster, &buildGroups)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	data.DataGroups = buildGroups.DataGroups
+	data.WitnessGroups = buildGroups.WitnessGroups
 
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -655,6 +655,7 @@ func (c *clusterResource) read(ctx context.Context, tfClusterResource *ClusterRe
 		tfClusterResource.FirstRecoverabilityPointAt = &firstPointAt
 	}
 
+	// pgConfig. If tf resource pg config elem matches with api response pg config elem then add the elem to tf resource pg config
 	newPgConfig := []PgConfigResourceModel{}
 	if configs := apiCluster.PgConfig; configs != nil {
 		for _, tfCRPgConfig := range tfClusterResource.PgConfig {

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -597,72 +597,72 @@ func (c *clusterResource) ImportState(ctx context.Context, req resource.ImportSt
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cluster_id"), idParts[1])...)
 }
 
-func (c *clusterResource) read(ctx context.Context, clusterResource *ClusterResourceModel) error {
-	cluster, err := c.client.Read(ctx, clusterResource.ProjectId, *clusterResource.ClusterId)
+func (c *clusterResource) read(ctx context.Context, tfClusterResource *ClusterResourceModel) error {
+	apiCluster, err := c.client.Read(ctx, tfClusterResource.ProjectId, *tfClusterResource.ClusterId)
 	if err != nil {
 		return err
 	}
 
-	connection, err := c.client.ConnectionString(ctx, clusterResource.ProjectId, *clusterResource.ClusterId)
+	connection, err := c.client.ConnectionString(ctx, tfClusterResource.ProjectId, *tfClusterResource.ClusterId)
 	if err != nil {
 		return err
 	}
 
-	clusterResource.ID = types.StringValue(fmt.Sprintf("%s/%s", clusterResource.ProjectId, *clusterResource.ClusterId))
-	clusterResource.ClusterId = cluster.ClusterId
-	clusterResource.ClusterName = types.StringPointerValue(cluster.ClusterName)
-	clusterResource.ClusterType = cluster.ClusterType
-	clusterResource.Phase = cluster.Phase
-	clusterResource.CloudProvider = types.StringValue(cluster.Provider.CloudProviderId)
-	clusterResource.ClusterArchitecture = &ClusterArchitectureResourceModel{
-		Id:    cluster.ClusterArchitecture.ClusterArchitectureId,
-		Nodes: cluster.ClusterArchitecture.Nodes,
-		Name:  types.StringValue(cluster.ClusterArchitecture.ClusterArchitectureName),
+	tfClusterResource.ID = types.StringValue(fmt.Sprintf("%s/%s", tfClusterResource.ProjectId, *tfClusterResource.ClusterId))
+	tfClusterResource.ClusterId = apiCluster.ClusterId
+	tfClusterResource.ClusterName = types.StringPointerValue(apiCluster.ClusterName)
+	tfClusterResource.ClusterType = apiCluster.ClusterType
+	tfClusterResource.Phase = apiCluster.Phase
+	tfClusterResource.CloudProvider = types.StringValue(apiCluster.Provider.CloudProviderId)
+	tfClusterResource.ClusterArchitecture = &ClusterArchitectureResourceModel{
+		Id:    apiCluster.ClusterArchitecture.ClusterArchitectureId,
+		Nodes: apiCluster.ClusterArchitecture.Nodes,
+		Name:  types.StringValue(apiCluster.ClusterArchitecture.ClusterArchitectureName),
 	}
-	clusterResource.Region = types.StringValue(cluster.Region.Id)
-	clusterResource.InstanceType = types.StringValue(cluster.InstanceType.InstanceTypeId)
-	clusterResource.Storage = &StorageResourceModel{
-		VolumeType:       types.StringPointerValue(cluster.Storage.VolumeTypeId),
-		VolumeProperties: types.StringPointerValue(cluster.Storage.VolumePropertiesId),
-		Size:             types.StringPointerValue(cluster.Storage.Size),
-		Iops:             types.StringPointerValue(cluster.Storage.Iops),
-		Throughput:       types.StringPointerValue(cluster.Storage.Throughput),
+	tfClusterResource.Region = types.StringValue(apiCluster.Region.Id)
+	tfClusterResource.InstanceType = types.StringValue(apiCluster.InstanceType.InstanceTypeId)
+	tfClusterResource.Storage = &StorageResourceModel{
+		VolumeType:       types.StringPointerValue(apiCluster.Storage.VolumeTypeId),
+		VolumeProperties: types.StringPointerValue(apiCluster.Storage.VolumePropertiesId),
+		Size:             types.StringPointerValue(apiCluster.Storage.Size),
+		Iops:             types.StringPointerValue(apiCluster.Storage.Iops),
+		Throughput:       types.StringPointerValue(apiCluster.Storage.Throughput),
 	}
-	clusterResource.ResizingPvc = StringSliceToList(cluster.ResizingPvc)
-	clusterResource.ReadOnlyConnections = types.BoolPointerValue(cluster.ReadOnlyConnections)
-	clusterResource.ConnectionUri = &connection.PgUri
-	clusterResource.RoConnectionUri = &connection.ReadOnlyPgUri
-	clusterResource.CspAuth = types.BoolPointerValue(cluster.CSPAuth)
-	clusterResource.LogsUrl = cluster.LogsUrl
-	clusterResource.MetricsUrl = cluster.MetricsUrl
-	clusterResource.BackupRetentionPeriod = types.StringPointerValue(cluster.BackupRetentionPeriod)
-	clusterResource.PgVersion = types.StringValue(cluster.PgVersion.PgVersionId)
-	clusterResource.PgType = types.StringValue(cluster.PgType.PgTypeId)
-	clusterResource.FarawayReplicaIds = StringSliceToSet(cluster.FarawayReplicaIds)
-	clusterResource.PrivateNetworking = types.BoolPointerValue(cluster.PrivateNetworking)
-	clusterResource.SuperuserAccess = types.BoolPointerValue(cluster.SuperuserAccess)
-	if cluster.Extensions != nil {
-		for _, v := range *cluster.Extensions {
+	tfClusterResource.ResizingPvc = StringSliceToList(apiCluster.ResizingPvc)
+	tfClusterResource.ReadOnlyConnections = types.BoolPointerValue(apiCluster.ReadOnlyConnections)
+	tfClusterResource.ConnectionUri = &connection.PgUri
+	tfClusterResource.RoConnectionUri = &connection.ReadOnlyPgUri
+	tfClusterResource.CspAuth = types.BoolPointerValue(apiCluster.CSPAuth)
+	tfClusterResource.LogsUrl = apiCluster.LogsUrl
+	tfClusterResource.MetricsUrl = apiCluster.MetricsUrl
+	tfClusterResource.BackupRetentionPeriod = types.StringPointerValue(apiCluster.BackupRetentionPeriod)
+	tfClusterResource.PgVersion = types.StringValue(apiCluster.PgVersion.PgVersionId)
+	tfClusterResource.PgType = types.StringValue(apiCluster.PgType.PgTypeId)
+	tfClusterResource.FarawayReplicaIds = StringSliceToSet(apiCluster.FarawayReplicaIds)
+	tfClusterResource.PrivateNetworking = types.BoolPointerValue(apiCluster.PrivateNetworking)
+	tfClusterResource.SuperuserAccess = types.BoolPointerValue(apiCluster.SuperuserAccess)
+	if apiCluster.Extensions != nil {
+		for _, v := range *apiCluster.Extensions {
 			if v.Enabled && v.ExtensionId == "pgvector" {
-				clusterResource.Pgvector = types.BoolValue(true)
+				tfClusterResource.Pgvector = types.BoolValue(true)
 				break
 			}
 		}
 	}
 
-	if cluster.FirstRecoverabilityPointAt != nil {
-		firstPointAt := cluster.FirstRecoverabilityPointAt.String()
-		clusterResource.FirstRecoverabilityPointAt = &firstPointAt
+	if apiCluster.FirstRecoverabilityPointAt != nil {
+		firstPointAt := apiCluster.FirstRecoverabilityPointAt.String()
+		tfClusterResource.FirstRecoverabilityPointAt = &firstPointAt
 	}
 
 	newPgConfig := []PgConfigResourceModel{}
-	if configs := cluster.PgConfig; configs != nil {
-		for _, cRPgConfig := range clusterResource.PgConfig {
-			for _, kv := range *configs {
-				if cRPgConfig.Value == kv.Value {
+	if configs := apiCluster.PgConfig; configs != nil {
+		for _, tfCRPgConfig := range tfClusterResource.PgConfig {
+			for _, apiConfig := range *configs {
+				if tfCRPgConfig.Name == apiConfig.Name {
 					newPgConfig = append(newPgConfig, PgConfigResourceModel{
-						Name:  kv.Name,
-						Value: kv.Value,
+						Name:  apiConfig.Name,
+						Value: apiConfig.Value,
 					})
 				}
 			}
@@ -670,43 +670,43 @@ func (c *clusterResource) read(ctx context.Context, clusterResource *ClusterReso
 	}
 
 	if len(newPgConfig) > 0 {
-		clusterResource.PgConfig = newPgConfig
+		tfClusterResource.PgConfig = newPgConfig
 	}
 
-	clusterResource.AllowedIpRanges = []AllowedIpRangesResourceModel{}
-	if allowedIpRanges := cluster.AllowedIpRanges; allowedIpRanges != nil {
+	tfClusterResource.AllowedIpRanges = []AllowedIpRangesResourceModel{}
+	if allowedIpRanges := apiCluster.AllowedIpRanges; allowedIpRanges != nil {
 		for _, ipRange := range *allowedIpRanges {
-			clusterResource.AllowedIpRanges = append(clusterResource.AllowedIpRanges, AllowedIpRangesResourceModel{
+			tfClusterResource.AllowedIpRanges = append(tfClusterResource.AllowedIpRanges, AllowedIpRangesResourceModel{
 				CidrBlock:   ipRange.CidrBlock,
 				Description: types.StringValue(ipRange.Description),
 			})
 		}
 	}
 
-	if pt := cluster.CreatedAt; pt != nil {
-		clusterResource.CreatedAt = types.StringValue(pt.String())
+	if pt := apiCluster.CreatedAt; pt != nil {
+		tfClusterResource.CreatedAt = types.StringValue(pt.String())
 	}
 
-	if cluster.MaintenanceWindow != nil {
-		clusterResource.MaintenanceWindow = &commonTerraform.MaintenanceWindow{
-			IsEnabled: cluster.MaintenanceWindow.IsEnabled,
-			StartDay:  types.Int64PointerValue(utils.ToPointer(int64(*cluster.MaintenanceWindow.StartDay))),
-			StartTime: types.StringPointerValue(cluster.MaintenanceWindow.StartTime),
+	if apiCluster.MaintenanceWindow != nil {
+		tfClusterResource.MaintenanceWindow = &commonTerraform.MaintenanceWindow{
+			IsEnabled: apiCluster.MaintenanceWindow.IsEnabled,
+			StartDay:  types.Int64PointerValue(utils.ToPointer(int64(*apiCluster.MaintenanceWindow.StartDay))),
+			StartTime: types.StringPointerValue(apiCluster.MaintenanceWindow.StartTime),
 		}
 	}
 
-	if cluster.PeAllowedPrincipalIds != nil {
-		clusterResource.PeAllowedPrincipalIds = StringSliceToSet(utils.ToValue(&cluster.PeAllowedPrincipalIds))
+	if apiCluster.PeAllowedPrincipalIds != nil {
+		tfClusterResource.PeAllowedPrincipalIds = StringSliceToSet(utils.ToValue(&apiCluster.PeAllowedPrincipalIds))
 	}
 
-	if cluster.ServiceAccountIds != nil {
-		clusterResource.ServiceAccountIds = StringSliceToSet(utils.ToValue(&cluster.ServiceAccountIds))
+	if apiCluster.ServiceAccountIds != nil {
+		tfClusterResource.ServiceAccountIds = StringSliceToSet(utils.ToValue(&apiCluster.ServiceAccountIds))
 	}
 
-	if cluster.PgBouncer != nil {
-		clusterResource.PgBouncer = &PgBouncerModel{}
-		*clusterResource.PgBouncer = PgBouncerModel{
-			IsEnabled: cluster.PgBouncer.IsEnabled,
+	if apiCluster.PgBouncer != nil {
+		tfClusterResource.PgBouncer = &PgBouncerModel{}
+		*tfClusterResource.PgBouncer = PgBouncerModel{
+			IsEnabled: apiCluster.PgBouncer.IsEnabled,
 		}
 
 		settingsElemType := map[string]attr.Type{"name": types.StringType, "operation": types.StringType, "value": types.StringType}
@@ -716,16 +716,16 @@ func (c *clusterResource) read(ctx context.Context, clusterResource *ClusterReso
 			"value":     basetypes.NewStringValue(""),
 		})
 
-		if !cluster.PgBouncer.IsEnabled {
-			clusterResource.PgBouncer.Settings = basetypes.NewSetNull(elem.Type(ctx))
-		} else if cluster.PgBouncer.IsEnabled &&
-			cluster.PgBouncer.Settings != nil &&
-			len(*cluster.PgBouncer.Settings) == 0 {
-			clusterResource.PgBouncer.Settings = basetypes.NewSetNull(elem.Type(ctx))
-		} else if cluster.PgBouncer.Settings != nil && len(*cluster.PgBouncer.Settings) > 0 {
+		if !apiCluster.PgBouncer.IsEnabled {
+			tfClusterResource.PgBouncer.Settings = basetypes.NewSetNull(elem.Type(ctx))
+		} else if apiCluster.PgBouncer.IsEnabled &&
+			apiCluster.PgBouncer.Settings != nil &&
+			len(*apiCluster.PgBouncer.Settings) == 0 {
+			tfClusterResource.PgBouncer.Settings = basetypes.NewSetNull(elem.Type(ctx))
+		} else if apiCluster.PgBouncer.Settings != nil && len(*apiCluster.PgBouncer.Settings) > 0 {
 			settings := []attr.Value{}
 
-			for _, v := range *cluster.PgBouncer.Settings {
+			for _, v := range *apiCluster.PgBouncer.Settings {
 				object := basetypes.NewObjectValueMust(settingsElemType, map[string]attr.Value{
 					"name":      basetypes.NewStringValue(*v.Name),
 					"operation": basetypes.NewStringValue(*v.Operation),
@@ -733,7 +733,7 @@ func (c *clusterResource) read(ctx context.Context, clusterResource *ClusterReso
 				})
 				settings = append(settings, object)
 			}
-			clusterResource.PgBouncer.Settings = basetypes.NewSetValueMust(elem.Type(ctx), settings)
+			tfClusterResource.PgBouncer.Settings = basetypes.NewSetValueMust(elem.Type(ctx), settings)
 		}
 	}
 

--- a/pkg/provider/resource_pgd.go
+++ b/pkg/provider/resource_pgd.go
@@ -211,7 +211,7 @@ func PgdSchema(ctx context.Context) schema.Schema {
 								},
 							},
 							PlanModifiers: []planmodifier.Set{
-								plan_modifier.CustomPGConfig(),
+								setplanmodifier.UseStateForUnknown(),
 							},
 						},
 						"cluster_architecture": schema.SingleNestedAttribute{

--- a/pkg/provider/resource_pgd.go
+++ b/pkg/provider/resource_pgd.go
@@ -1114,12 +1114,10 @@ func buildTFGroupsAs(ctx context.Context, diags *diag.Diagnostics, state tfsdk.S
 				// pgConfig
 				var newPgConfig []models.KeyValue
 				var tfPgConfig *[]models.KeyValue
-				if originalTFDgs != nil {
-					for _, pgdTFResourceDG := range originalTFDgs {
-						if pgdTFResourceDG.Region.RegionId == apiDGModel.Region.RegionId {
-							tfPgConfig = pgdTFResourceDG.PgConfig
-							break
-						}
+				for _, pgdTFResourceDG := range originalTFDgs {
+					if pgdTFResourceDG.Region.RegionId == apiDGModel.Region.RegionId {
+						tfPgConfig = pgdTFResourceDG.PgConfig
+						break
 					}
 				}
 

--- a/pkg/provider/resource_pgd.go
+++ b/pkg/provider/resource_pgd.go
@@ -1111,7 +1111,7 @@ func buildTFGroupsAs(ctx context.Context, diags *diag.Diagnostics, state tfsdk.S
 					conditionsSet = types.SetValueMust(conditionsElemType, conditions)
 				}
 
-				// pgConfig
+				// pgConfig. If tf resource pg config elem matches with api response pg config elem then add the elem to tf resource pg config
 				var newPgConfig []models.KeyValue
 				var tfPgConfig *[]models.KeyValue
 				for _, pgdTFResourceDG := range originalTFDgs {


### PR DESCRIPTION
I have removed default pg configs in the response so only user custom pg configs show like:
![image](https://github.com/EnterpriseDB/terraform-provider-biganimal/assets/119956756/0245413a-6ae1-4dd7-9920-f80410606fec)

before it use to have a lot more elements because of the defaults. This is a more future solution as defaults can be added/removed from the backend in future and cause a mismatch in our plan and response state. 