### PR TITLE
chore: Update AWS instance type example to use series 6

### DIFF
--- a/docs/data-sources/analytics_cluster.md
+++ b/docs/data-sources/analytics_cluster.md
@@ -120,7 +120,7 @@ output "service_account_ids" {
 - `created_at` (String) Cluster creation time.
 - `first_recoverability_point_at` (String) Earliest backup recover time.
 - `id` (String) Resource ID of the cluster.
-- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c5.large" or "gcp:e2-highcpu-4".
+- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c6i.large" or "gcp:e2-highcpu-4".
 - `logs_url` (String) The URL to find the logs of this cluster.
 - `metrics_url` (String) The URL to find the metrics of this cluster.
 - `password` (String) Password for the user edb_admin. It must be 12 characters or more.

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -163,7 +163,7 @@ output "volume_snapshot_backup" {
 - `faraway_replica_ids` (Set of String)
 - `first_recoverability_point_at` (String) Earliest backup recover time.
 - `id` (String) Data source ID.
-- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c5.large" or "gcp:e2-highcpu-4".
+- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c6i.large" or "gcp:e2-highcpu-4".
 - `logs_url` (String) The URL to find the logs of this cluster.
 - `metrics_url` (String) The URL to find the metrics of this cluster.
 - `password` (String) Password for the user edb_admin. It must be 12 characters or more.

--- a/docs/data-sources/faraway_replica.md
+++ b/docs/data-sources/faraway_replica.md
@@ -138,7 +138,7 @@ output "volume_snapshot_backup" {
 - `connection_uri` (String) Cluster connection URI.
 - `created_at` (String) Cluster creation time.
 - `id` (String) The ID of this resource.
-- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c5.large" or "gcp:e2-highcpu-4".
+- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c6i.large" or "gcp:e2-highcpu-4".
 - `logs_url` (String) The URL to find the logs of this cluster.
 - `metrics_url` (String) The URL to find the metrics of this cluster.
 - `pg_identity` (String) PG Identity required to grant key permissions to activate the cluster.

--- a/docs/resources/analytics_cluster.md
+++ b/docs/resources/analytics_cluster.md
@@ -19,7 +19,7 @@ The analytics cluster resource is used to manage BigAnimal analytics clusters.
 
 - `cloud_provider` (String) Cloud provider. For example, "aws" or "bah:aws".
 - `cluster_name` (String) Name of the cluster.
-- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c5.large" or "gcp:e2-highcpu-4".
+- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c6i.large" or "gcp:e2-highcpu-4".
 - `password` (String) Password for the user edb_admin. It must be 12 characters or more.
 - `pg_type` (String) Postgres type. For example, "epas" or "pgextended".
 - `pg_version` (String) Postgres version. For example 16

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -61,7 +61,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
   csp_auth = false
 
-  instance_type = "aws:m5.large"
+  instance_type = "aws:m6i.large"
   password      = resource.random_password.password.result
   pg_config = [
     {
@@ -185,7 +185,7 @@ resource "biganimal_cluster" "ha_cluster" {
     nodes = 3
   }
 
-  instance_type = "aws:c5.large"
+  instance_type = "aws:c6i.large"
   password      = resource.random_password.password.result
   pg_config = [
     {
@@ -268,7 +268,7 @@ output "faraway_replica_ids" {
 - `cloud_provider` (String) Cloud provider. For example, "aws", "azure", "gcp" or "bah:aws", "bah:gcp".
 - `cluster_architecture` (Attributes) Cluster architecture. (see [below for nested schema](#nestedatt--cluster_architecture))
 - `cluster_name` (String) Name of the cluster.
-- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c5.large" or "gcp:e2-highcpu-4".
+- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c6i.large" or "gcp:e2-highcpu-4".
 - `password` (String) Password for the user edb_admin. It must be 12 characters or more.
 - `pg_type` (String) Postgres type. For example, "epas", "pgextended", or "postgres".
 - `pg_version` (String) Postgres version. See [Supported Postgres types and versions](https://www.enterprisedb.com/docs/biganimal/latest/overview/05_database_version_policy/#supported-postgres-types-and-versions) for supported Postgres types and versions.

--- a/docs/resources/faraway_replica.md
+++ b/docs/resources/faraway_replica.md
@@ -132,7 +132,7 @@ resource "biganimal_faraway_replica" "faraway_replica" {
 ### Required
 
 - `cluster_name` (String) Name of the faraway replica cluster.
-- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c5.large" or "gcp:e2-highcpu-4".
+- `instance_type` (String) Instance type. For example, "azure:Standard_D2s_v3", "aws:c6i.large" or "gcp:e2-highcpu-4".
 - `region` (String) Region to deploy the cluster. See [Supported regions](https://www.enterprisedb.com/docs/biganimal/latest/overview/03a_region_support/) for supported regions.
 - `source_cluster_id` (String) Source cluster ID.
 - `storage` (Attributes) Storage. (see [below for nested schema](#nestedatt--storage))

--- a/docs/resources/pgd.md
+++ b/docs/resources/pgd.md
@@ -337,7 +337,7 @@ resource "biganimal_pgd" "pgd_cluster" {
       }
       csp_auth = false
       instance_type = {
-        instance_type_id = "aws:m5.large"
+        instance_type_id = "aws:m6i.large"
       }
       pg_config = [
         {
@@ -440,7 +440,7 @@ resource "biganimal_pgd" "pgd_cluster" {
       }
       csp_auth = false
       instance_type = {
-        instance_type_id = "aws:m5.large"
+        instance_type_id = "aws:m6i.large"
       }
       pg_config = [
         {
@@ -497,7 +497,7 @@ resource "biganimal_pgd" "pgd_cluster" {
       }
       csp_auth = false
       instance_type = {
-        instance_type_id = "aws:m5.large"
+        instance_type_id = "aws:m6i.large"
       }
       pg_config = [
         {

--- a/examples/resources/biganimal_cluster/ha/resource.tf
+++ b/examples/resources/biganimal_cluster/ha/resource.tf
@@ -49,7 +49,7 @@ resource "biganimal_cluster" "ha_cluster" {
     nodes = 3
   }
 
-  instance_type = "aws:c5.large"
+  instance_type = "aws:c6i.large"
   password      = resource.random_password.password.result
   pg_config = [
     {

--- a/examples/resources/biganimal_cluster/single_node/aws/resource.tf
+++ b/examples/resources/biganimal_cluster/single_node/aws/resource.tf
@@ -50,7 +50,7 @@ resource "biganimal_cluster" "single_node_cluster" {
   }
   csp_auth = false
 
-  instance_type = "aws:m5.large"
+  instance_type = "aws:m6i.large"
   password      = resource.random_password.password.result
   pg_config = [
     {

--- a/examples/resources/biganimal_pgd/aws/data_group/resource.tf
+++ b/examples/resources/biganimal_pgd/aws/data_group/resource.tf
@@ -51,7 +51,7 @@ resource "biganimal_pgd" "pgd_cluster" {
       }
       csp_auth = false
       instance_type = {
-        instance_type_id = "aws:m5.large"
+        instance_type_id = "aws:m6i.large"
       }
       pg_config = [
         {

--- a/examples/resources/biganimal_pgd/aws/data_groups_with_witness_group/resource.tf
+++ b/examples/resources/biganimal_pgd/aws/data_groups_with_witness_group/resource.tf
@@ -51,7 +51,7 @@ resource "biganimal_pgd" "pgd_cluster" {
       }
       csp_auth = false
       instance_type = {
-        instance_type_id = "aws:m5.large"
+        instance_type_id = "aws:m6i.large"
       }
       pg_config = [
         {
@@ -108,7 +108,7 @@ resource "biganimal_pgd" "pgd_cluster" {
       }
       csp_auth = false
       instance_type = {
-        instance_type_id = "aws:m5.large"
+        instance_type_id = "aws:m6i.large"
       }
       pg_config = [
         {

--- a/pkg/plan_modifier/data_group_custom_diff_test.go
+++ b/pkg/plan_modifier/data_group_custom_diff_test.go
@@ -93,7 +93,7 @@ func Test_customDataGroupDiffModifier_PlanModifyList(t *testing.T) {
 				Nodes:                   3,
 				WitnessNodes:            basetypes.NewInt64Unknown(),
 			},
-			InstanceType: &api.InstanceType{InstanceTypeId: "aws:m5.large"},
+			InstanceType: &api.InstanceType{InstanceTypeId: "aws:m6i.large"},
 			PgType:       &api.PgType{PgTypeId: "epas"},
 			PgVersion:    &api.PgVersion{PgVersionId: "15"},
 			MaintenanceWindow: &models.MaintenanceWindow{

--- a/pkg/provider/data_source_analytics_cluster.go
+++ b/pkg/provider/data_source_analytics_cluster.go
@@ -133,7 +133,7 @@ func (r *analyticsClusterDataSource) Schema(ctx context.Context, req datasource.
 				Computed:            true,
 			},
 			"instance_type": schema.StringAttribute{
-				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c5.large\" or \"gcp:e2-highcpu-4\".",
+				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c6i.large\" or \"gcp:e2-highcpu-4\".",
 				Computed:            true,
 			},
 			"resizing_pvc": schema.ListAttribute{

--- a/pkg/provider/data_source_cluster.go
+++ b/pkg/provider/data_source_cluster.go
@@ -240,7 +240,7 @@ func (c *clusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				Computed:            true,
 			},
 			"instance_type": schema.StringAttribute{
-				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c5.large\" or \"gcp:e2-highcpu-4\".",
+				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c6i.large\" or \"gcp:e2-highcpu-4\".",
 				Computed:            true,
 			},
 			"read_only_connections": schema.BoolAttribute{

--- a/pkg/provider/data_source_fareplica.go
+++ b/pkg/provider/data_source_fareplica.go
@@ -90,7 +90,7 @@ func (c *FAReplicaData) Schema(ctx context.Context, req datasource.SchemaRequest
 				Computed:    true,
 			},
 			"instance_type": schema.StringAttribute{
-				Description: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c5.large\" or \"gcp:e2-highcpu-4\".",
+				Description: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c6i.large\" or \"gcp:e2-highcpu-4\".",
 				Computed:    true,
 			},
 			"logs_url": schema.StringAttribute{

--- a/pkg/provider/resource_analytics_cluster.go
+++ b/pkg/provider/resource_analytics_cluster.go
@@ -203,7 +203,7 @@ func (r *analyticsClusterResource) Schema(ctx context.Context, req resource.Sche
 				Required:            true,
 			},
 			"instance_type": schema.StringAttribute{
-				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c5.large\" or \"gcp:e2-highcpu-4\".",
+				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c6i.large\" or \"gcp:e2-highcpu-4\".",
 				Required:            true,
 			},
 			"resizing_pvc": schema.ListAttribute{

--- a/pkg/provider/resource_cluster.go
+++ b/pkg/provider/resource_cluster.go
@@ -367,7 +367,7 @@ func (c *clusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Required:            true,
 			},
 			"instance_type": schema.StringAttribute{
-				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c5.large\" or \"gcp:e2-highcpu-4\".",
+				MarkdownDescription: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c6i.large\" or \"gcp:e2-highcpu-4\".",
 				Required:            true,
 			},
 			"read_only_connections": schema.BoolAttribute{

--- a/pkg/provider/resource_cluster_test.go
+++ b/pkg/provider/resource_cluster_test.go
@@ -36,7 +36,7 @@ func TestAccResourceCluster_basic(t *testing.T) {
 			{
 				Config: clusterResourceConfig(accClusterName, accProjectID, accProvider, accRegion),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("biganimal_cluster.acctest_cluster", "instance_type", "aws:m5.large"),
+					resource.TestCheckResourceAttr("biganimal_cluster.acctest_cluster", "instance_type", "aws:m6i.large"),
 					resource.TestCheckResourceAttr("biganimal_cluster.acctest_cluster", "storage.volume_type", "gp3"),
 					resource.TestCheckResourceAttr("biganimal_cluster.acctest_cluster", "storage.size", "4 Gi"),
 					resource.TestCheckResourceAttr("biganimal_cluster.acctest_cluster", "pg_type", "epas"),
@@ -72,7 +72,7 @@ func clusterResourceConfig(cluster_name, projectID, provider, region string) str
   }
   csp_auth = false
 
-  instance_type = "aws:m5.large"
+  instance_type = "aws:m6i.large"
 
   storage {
     volume_type       = "gp3"
@@ -125,7 +125,7 @@ func clusterResourceConfigForUpdate(cluster_name, projectID, provider, region st
   }
   csp_auth = true
 
-  instance_type = "aws:m5.large"
+  instance_type = "aws:m6i.large"
 
   storage {
     volume_type       = "gp3"

--- a/pkg/provider/resource_fareplica.go
+++ b/pkg/provider/resource_fareplica.go
@@ -167,7 +167,7 @@ func (r *FAReplicaResource) Schema(ctx context.Context, req resource.SchemaReque
 				},
 			},
 			"instance_type": schema.StringAttribute{
-				Description: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c5.large\" or \"gcp:e2-highcpu-4\".",
+				Description: "Instance type. For example, \"azure:Standard_D2s_v3\", \"aws:c6i.large\" or \"gcp:e2-highcpu-4\".",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),


### PR DESCRIPTION
This PR is intended to update the cluster provisioning options in AWS biganimal TF provider to use the 6 series instead of the 5 series. 